### PR TITLE
[smtlib] use smtValue to emit declare-const

### DIFF
--- a/smtlib/src/Api.scala
+++ b/smtlib/src/Api.scala
@@ -34,7 +34,7 @@ trait ConstructorApi:
   ): Sort[T]
 
   // values
-  def SMTFunc[T <: Data](
+  def smtValue[T <: Data](
     rangeType: T
   )(
     using Arena,
@@ -43,7 +43,19 @@ trait ConstructorApi:
     sourcecode.File,
     sourcecode.Line,
     sourcecode.Name
-  ): Ref[SMTFunc[?, T]]
+  ): Ref[T]
+
+  def smtFunc[T <: Data, U <: Data](
+    domainTypes: Seq[T],
+    rangeType:   U
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name
+  ): Ref[SMTFunc[T, U]]
 
   // smt functions
   def smtDistinct[T <: Data, D <: Referable[T]](

--- a/smtlib/tests/src/ExportSMTLIBSpec.scala
+++ b/smtlib/tests/src/ExportSMTLIBSpec.scala
@@ -35,136 +35,88 @@ object ExportSMTLIBSpec extends TestSuite:
     test("Sudoku"):
       smtTest(
         "(set-logic QF_LIA)",
-        "(declare-fun f1 () Int)",
-        "(declare-fun f2 () Int)",
-        "(declare-fun f3 () Int)",
-        "(declare-fun f4 () Int)",
-        "(declare-fun f5 () Int)",
-        "(declare-fun f6 () Int)",
-        "(declare-fun f7 () Int)",
-        "(declare-fun f8 () Int)",
-        "(declare-fun f9 () Int)",
-        "(declare-fun s () Int)",
+        "(declare-const f1 Int)",
+        "(declare-const f2 Int)",
+        "(declare-const f3 Int)",
+        "(declare-const f4 Int)",
+        "(declare-const f5 Int)",
+        "(declare-const f6 Int)",
+        "(declare-const f7 Int)",
+        "(declare-const f8 Int)",
+        "(declare-const f9 Int)",
+        "(declare-const s Int)",
         "(assert (let ((tmp (distinct f1 f2 f3 f4 f5 f6 f7 f8 f9)))",
-        "        (let ((tmp_0 (f9)))",
-        "        (let ((tmp_1 (<= tmp_0 9)))",
-        "        (let ((tmp_2 (f9)))",
-        "        (let ((tmp_3 (>= tmp_2 1)))",
-        "        (let ((tmp_4 (f8)))",
-        "        (let ((tmp_5 (<= tmp_4 9)))",
-        "        (let ((tmp_6 (f8)))",
-        "        (let ((tmp_7 (>= tmp_6 1)))",
-        "        (let ((tmp_8 (f7)))",
-        "        (let ((tmp_9 (<= tmp_8 9)))",
-        "        (let ((tmp_10 (f7)))",
-        "        (let ((tmp_11 (>= tmp_10 1)))",
-        "        (let ((tmp_12 (f6)))",
-        "        (let ((tmp_13 (<= tmp_12 9)))",
-        "        (let ((tmp_14 (f6)))",
-        "        (let ((tmp_15 (>= tmp_14 1)))",
-        "        (let ((tmp_16 (f5)))",
-        "        (let ((tmp_17 (<= tmp_16 9)))",
-        "        (let ((tmp_18 (f5)))",
-        "        (let ((tmp_19 (>= tmp_18 1)))",
-        "        (let ((tmp_20 (f4)))",
-        "        (let ((tmp_21 (<= tmp_20 9)))",
-        "        (let ((tmp_22 (f4)))",
-        "        (let ((tmp_23 (>= tmp_22 1)))",
-        "        (let ((tmp_24 (f3)))",
-        "        (let ((tmp_25 (<= tmp_24 9)))",
-        "        (let ((tmp_26 (f3)))",
-        "        (let ((tmp_27 (>= tmp_26 1)))",
-        "        (let ((tmp_28 (f2)))",
-        "        (let ((tmp_29 (<= tmp_28 9)))",
-        "        (let ((tmp_30 (f2)))",
-        "        (let ((tmp_31 (>= tmp_30 1)))",
-        "        (let ((tmp_32 (f1)))",
-        "        (let ((tmp_33 (<= tmp_32 9)))",
-        "        (let ((tmp_34 (f1)))",
-        "        (let ((tmp_35 (>= tmp_34 1)))",
-        "        (let ((tmp_36 (and tmp_35 tmp_33)))",
-        "        (let ((tmp_37 (and tmp_36 tmp_31)))",
-        "        (let ((tmp_38 (and tmp_37 tmp_29)))",
-        "        (let ((tmp_39 (and tmp_38 tmp_27)))",
-        "        (let ((tmp_40 (and tmp_39 tmp_25)))",
-        "        (let ((tmp_41 (and tmp_40 tmp_23)))",
-        "        (let ((tmp_42 (and tmp_41 tmp_21)))",
-        "        (let ((tmp_43 (and tmp_42 tmp_19)))",
-        "        (let ((tmp_44 (and tmp_43 tmp_17)))",
-        "        (let ((tmp_45 (and tmp_44 tmp_15)))",
-        "        (let ((tmp_46 (and tmp_45 tmp_13)))",
-        "        (let ((tmp_47 (and tmp_46 tmp_11)))",
-        "        (let ((tmp_48 (and tmp_47 tmp_9)))",
-        "        (let ((tmp_49 (and tmp_48 tmp_7)))",
-        "        (let ((tmp_50 (and tmp_49 tmp_5)))",
-        "        (let ((tmp_51 (and tmp_50 tmp_3)))",
-        "        (let ((tmp_52 (and tmp_51 tmp_1)))",
-        "        (let ((tmp_53 (and tmp_52 tmp)))",
-        "        tmp_53))))))))))))))))))))))))))))))))))))))))))))))))))))))))",
-        "(assert (let ((tmp_54 (f3)))",
-        "        (let ((tmp_55 (f2)))",
-        "        (let ((tmp_56 (f1)))",
-        "        (let ((tmp_57 (+ tmp_56 tmp_55)))",
-        "        (let ((tmp_58 (+ tmp_57 tmp_54)))",
-        "        (let ((tmp_59 (s)))",
-        "        (let ((tmp_60 (= tmp_59 tmp_58)))",
-        "        tmp_60))))))))",
-        "(assert (let ((tmp_61 (f6)))",
-        "        (let ((tmp_62 (f5)))",
-        "        (let ((tmp_63 (f4)))",
-        "        (let ((tmp_64 (+ tmp_63 tmp_62)))",
-        "        (let ((tmp_65 (+ tmp_64 tmp_61)))",
-        "        (let ((tmp_66 (s)))",
-        "        (let ((tmp_67 (= tmp_66 tmp_65)))",
-        "        tmp_67))))))))",
-        "(assert (let ((tmp_68 (f9)))",
-        "        (let ((tmp_69 (f8)))",
-        "        (let ((tmp_70 (f7)))",
-        "        (let ((tmp_71 (+ tmp_70 tmp_69)))",
-        "        (let ((tmp_72 (+ tmp_71 tmp_68)))",
-        "        (let ((tmp_73 (s)))",
-        "        (let ((tmp_74 (= tmp_73 tmp_72)))",
-        "        tmp_74))))))))",
-        "(assert (let ((tmp_75 (f7)))",
-        "        (let ((tmp_76 (f4)))",
-        "        (let ((tmp_77 (f1)))",
-        "        (let ((tmp_78 (+ tmp_77 tmp_76)))",
-        "        (let ((tmp_79 (+ tmp_78 tmp_75)))",
-        "        (let ((tmp_80 (s)))",
-        "        (let ((tmp_81 (= tmp_80 tmp_79)))",
-        "        tmp_81))))))))",
-        "(assert (let ((tmp_82 (f8)))",
-        "        (let ((tmp_83 (f5)))",
-        "        (let ((tmp_84 (f2)))",
-        "        (let ((tmp_85 (+ tmp_84 tmp_83)))",
-        "        (let ((tmp_86 (+ tmp_85 tmp_82)))",
-        "        (let ((tmp_87 (s)))",
-        "        (let ((tmp_88 (= tmp_87 tmp_86)))",
-        "        tmp_88))))))))",
-        "(assert (let ((tmp_89 (f9)))",
-        "        (let ((tmp_90 (f6)))",
-        "        (let ((tmp_91 (f3)))",
-        "        (let ((tmp_92 (+ tmp_91 tmp_90)))",
-        "        (let ((tmp_93 (+ tmp_92 tmp_89)))",
-        "        (let ((tmp_94 (s)))",
-        "        (let ((tmp_95 (= tmp_94 tmp_93)))",
-        "        tmp_95))))))))",
-        "(assert (let ((tmp_96 (f9)))",
-        "        (let ((tmp_97 (f5)))",
-        "        (let ((tmp_98 (f1)))",
-        "        (let ((tmp_99 (+ tmp_98 tmp_97)))",
-        "        (let ((tmp_100 (+ tmp_99 tmp_96)))",
-        "        (let ((tmp_101 (s)))",
-        "        (let ((tmp_102 (= tmp_101 tmp_100)))",
-        "        tmp_102))))))))",
-        "(assert (let ((tmp_103 (f7)))",
-        "        (let ((tmp_104 (f5)))",
-        "        (let ((tmp_105 (f3)))",
-        "        (let ((tmp_106 (+ tmp_105 tmp_104)))",
-        "        (let ((tmp_107 (+ tmp_106 tmp_103)))",
-        "        (let ((tmp_108 (s)))",
-        "        (let ((tmp_109 (= tmp_108 tmp_107)))",
-        "        tmp_109))))))))"
+        "        (let ((tmp_0 (<= f9 9)))",
+        "        (let ((tmp_1 (>= f9 1)))",
+        "        (let ((tmp_2 (<= f8 9)))",
+        "        (let ((tmp_3 (>= f8 1)))",
+        "        (let ((tmp_4 (<= f7 9)))",
+        "        (let ((tmp_5 (>= f7 1)))",
+        "        (let ((tmp_6 (<= f6 9)))",
+        "        (let ((tmp_7 (>= f6 1)))",
+        "        (let ((tmp_8 (<= f5 9)))",
+        "        (let ((tmp_9 (>= f5 1)))",
+        "        (let ((tmp_10 (<= f4 9)))",
+        "        (let ((tmp_11 (>= f4 1)))",
+        "        (let ((tmp_12 (<= f3 9)))",
+        "        (let ((tmp_13 (>= f3 1)))",
+        "        (let ((tmp_14 (<= f2 9)))",
+        "        (let ((tmp_15 (>= f2 1)))",
+        "        (let ((tmp_16 (<= f1 9)))",
+        "        (let ((tmp_17 (>= f1 1)))",
+        "        (let ((tmp_18 (and tmp_17 tmp_16)))",
+        "        (let ((tmp_19 (and tmp_18 tmp_15)))",
+        "        (let ((tmp_20 (and tmp_19 tmp_14)))",
+        "        (let ((tmp_21 (and tmp_20 tmp_13)))",
+        "        (let ((tmp_22 (and tmp_21 tmp_12)))",
+        "        (let ((tmp_23 (and tmp_22 tmp_11)))",
+        "        (let ((tmp_24 (and tmp_23 tmp_10)))",
+        "        (let ((tmp_25 (and tmp_24 tmp_9)))",
+        "        (let ((tmp_26 (and tmp_25 tmp_8)))",
+        "        (let ((tmp_27 (and tmp_26 tmp_7)))",
+        "        (let ((tmp_28 (and tmp_27 tmp_6)))",
+        "        (let ((tmp_29 (and tmp_28 tmp_5)))",
+        "        (let ((tmp_30 (and tmp_29 tmp_4)))",
+        "        (let ((tmp_31 (and tmp_30 tmp_3)))",
+        "        (let ((tmp_32 (and tmp_31 tmp_2)))",
+        "        (let ((tmp_33 (and tmp_32 tmp_1)))",
+        "        (let ((tmp_34 (and tmp_33 tmp_0)))",
+        "        (let ((tmp_35 (and tmp_34 tmp)))",
+        "        tmp_35))))))))))))))))))))))))))))))))))))))",
+        "(assert (let ((tmp_36 (+ f1 f2)))",
+        "        (let ((tmp_37 (+ tmp_36 f3)))",
+        "        (let ((tmp_38 (= s tmp_37)))",
+        "        tmp_38))))",
+        "(assert (let ((tmp_39 (+ f4 f5)))",
+        "        (let ((tmp_40 (+ tmp_39 f6)))",
+        "        (let ((tmp_41 (= s tmp_40)))",
+        "        tmp_41))))",
+        "(assert (let ((tmp_42 (+ f7 f8)))",
+        "        (let ((tmp_43 (+ tmp_42 f9)))",
+        "        (let ((tmp_44 (= s tmp_43)))",
+        "        tmp_44))))",
+        "(assert (let ((tmp_45 (+ f1 f4)))",
+        "        (let ((tmp_46 (+ tmp_45 f7)))",
+        "        (let ((tmp_47 (= s tmp_46)))",
+        "        tmp_47))))",
+        "(assert (let ((tmp_48 (+ f2 f5)))",
+        "        (let ((tmp_49 (+ tmp_48 f8)))",
+        "        (let ((tmp_50 (= s tmp_49)))",
+        "        tmp_50))))",
+        "(assert (let ((tmp_51 (+ f3 f6)))",
+        "        (let ((tmp_52 (+ tmp_51 f9)))",
+        "        (let ((tmp_53 (= s tmp_52)))",
+        "        tmp_53))))",
+        "(assert (let ((tmp_54 (+ f1 f5)))",
+        "        (let ((tmp_55 (+ tmp_54 f9)))",
+        "        (let ((tmp_56 (= s tmp_55)))",
+        "        tmp_56))))",
+        "(assert (let ((tmp_57 (+ f3 f5)))",
+        "        (let ((tmp_58 (+ tmp_57 f7)))",
+        "        (let ((tmp_59 (= s tmp_58)))",
+        "        tmp_59))))",
+        "(check-sat)",
+        "(reset)"
       ):
         // smt-lib2 format
         solver {
@@ -182,16 +134,16 @@ object ExportSMTLIBSpec extends TestSuite:
           // (declare-fun f9 () Int)
           // (declare-fun s () Int)
 
-          val f1 = SMTFunc(SInt)
-          val f2 = SMTFunc(SInt)
-          val f3 = SMTFunc(SInt)
-          val f4 = SMTFunc(SInt)
-          val f5 = SMTFunc(SInt)
-          val f6 = SMTFunc(SInt)
-          val f7 = SMTFunc(SInt)
-          val f8 = SMTFunc(SInt)
-          val f9 = SMTFunc(SInt)
-          val s  = SMTFunc(SInt)
+          val f1 = smtValue(SInt)
+          val f2 = smtValue(SInt)
+          val f3 = smtValue(SInt)
+          val f4 = smtValue(SInt)
+          val f5 = smtValue(SInt)
+          val f6 = smtValue(SInt)
+          val f7 = smtValue(SInt)
+          val f8 = smtValue(SInt)
+          val f9 = smtValue(SInt)
+          val s  = smtValue(SInt)
 
           // (assert (and (>= f1 1) (<= f1 9)))
           // (assert (and (>= f2 1) (<= f2 9)))
@@ -205,9 +157,9 @@ object ExportSMTLIBSpec extends TestSuite:
           // (assert (distinct f1 f2 f3 f4 f5 f6 f7 f8 f9))
 
           smtAssert(
-            f1() >= 1.S & f1() <= 9.S & f2() >= 1.S & f2() <= 9.S & f3() >= 1.S & f3() <= 9.S & f4() >= 1.S & f4() <= 9.S &
-              f5() >= 1.S & f5() <= 9.S & f6() >= 1.S & f6() <= 9.S & f7() >= 1.S & f7() <= 9.S & f8() >= 1.S & f8() <= 9.S &
-              f9() >= 1.S & f9() <= 9.S & smtDistinct(f1, f2, f3, f4, f5, f6, f7, f8, f9)
+            f1 >= 1.S & f1 <= 9.S & f2 >= 1.S & f2 <= 9.S & f3 >= 1.S & f3 <= 9.S & f4 >= 1.S & f4 <= 9.S &
+              f5 >= 1.S & f5 <= 9.S & f6 >= 1.S & f6 <= 9.S & f7 >= 1.S & f7 <= 9.S & f8 >= 1.S & f8 <= 9.S &
+              f9 >= 1.S & f9 <= 9.S & smtDistinct(f1, f2, f3, f4, f5, f6, f7, f8, f9)
           )
 
           // (assert (= s ( f1 f2 f3)))
@@ -219,14 +171,14 @@ object ExportSMTLIBSpec extends TestSuite:
           // (assert (= s (+ f1 f5 f9)))
           // (assert (= s (+ f3 f5 f7)))
 
-          smtAssert(s() === f1() + f2() + f3())
-          smtAssert(s() === f4() + f5() + f6())
-          smtAssert(s() === f7() + f8() + f9())
-          smtAssert(s() === f1() + f4() + f7())
-          smtAssert(s() === f2() + f5() + f8())
-          smtAssert(s() === f3() + f6() + f9())
-          smtAssert(s() === f1() + f5() + f9())
-          smtAssert(s() === f3() + f5() + f7())
+          smtAssert(s === f1 + f2 + f3)
+          smtAssert(s === f4 + f5 + f6)
+          smtAssert(s === f7 + f8 + f9)
+          smtAssert(s === f1 + f4 + f7)
+          smtAssert(s === f2 + f5 + f8)
+          smtAssert(s === f3 + f6 + f9)
+          smtAssert(s === f1 + f5 + f9)
+          smtAssert(s === f3 + f5 + f7)
 
           // (check-sat)
           // (get-model)

--- a/smtlib/tests/src/QuantifierSpec.scala
+++ b/smtlib/tests/src/QuantifierSpec.scala
@@ -12,30 +12,29 @@ object QuantifierSpec extends TestSuite:
   val tests = Tests:
     test("Exist"):
       smtTest(
+        "(declare-const x Int)",
         "(assert (let ((tmp (exists ()",
-        "                           ( ! (let ((tmp_0 (x)))",
-        "                           (let ((tmp_1 (= tmp_0 1)))",
-        "                           tmp_1)) :weight 1))))",
+        "                           ( ! (let ((tmp_0 (= x 1)))",
+        "                           tmp_0) :weight 1))))",
         "        tmp))"
       ):
         solver {
           smtAssert(smtExists(1, false, Seq.empty) {
-            val x = SMTFunc(SInt)
-            smtYield(x() === 1.S)
+            val x = smtValue(SInt)
+            smtYield(x === 1.S)
           })
         }
     test("Forall"):
       smtTest(
-        "(declare-fun x () Int)",
+        "(declare-const x Int)",
         "(assert (let ((tmp (forall ()",
-        "                           ( ! (let ((tmp_0 (x)))",
-        "                           (let ((tmp_1 (= tmp_0 1)))",
-        "                           tmp_1)) :weight 1))))",
+        "                           ( ! (let ((tmp_0 (= x 1)))",
+        "                           tmp_0) :weight 1))))",
         "        tmp))"
       ):
         solver {
           smtAssert(smtForall(1, false, Seq.empty) {
-            val x = SMTFunc(SInt)
-            smtYield(x() === 1.S)
+            val x = smtValue(SInt)
+            smtYield(x === 1.S)
           })
         }

--- a/smtlib/tests/src/TypeSpec.scala
+++ b/smtlib/tests/src/TypeSpec.scala
@@ -14,709 +14,641 @@ object TypeSpec extends TestSuite:
     test("Const"):
       test("BitVector"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (= tmp #x00000000)))",
-          "        tmp_0)))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp (= a #x00000000)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(a() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(a === 0.B(true, 32))
           }
       test("Bool"):
-        smtTest("assert true"):
+        smtTest(
+          "(assert true)"
+        ):
           solver {
             smtAssert(true.B)
           }
-        smtTest("assert false"):
+        smtTest(
+          "(assert false)"
+        ):
           solver {
             smtAssert(false.B)
           }
       test("Int"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (= tmp 1)))",
-          "        tmp_0)))"
+          "(declare-const a Int)",
+          "(assert (let ((tmp (= a 1)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            smtAssert(a() === 1.S)
+            val a = smtValue(SInt)
+            smtAssert(a === 1.S)
           }
         smtTest(
-          "(declare-fun a () Int)",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (= tmp 0)))",
-          "        tmp_0)))"
+          "(declare-const a Int)",
+          "(assert (let ((tmp (= a 0)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            smtAssert(a() === 0.S)
+            val a = smtValue(SInt)
+            smtAssert(a === 0.S)
           }
     test("Array"):
       test("declare"):
         smtTest(
-          "(declare-fun a () (Array Int Bool))"
+          "(declare-const a (Array Int Bool))"
         ):
           solver {
-            val a = SMTFunc(Array(SInt, Bool))
+            val a = smtValue(Array(SInt, Bool))
           }
       test("select"):
         smtTest(
-          "(declare-fun a () (Array Int Bool))",
-          "(assert (let ((tmp (a)))",
+          "(declare-const a (Array Int Bool))",
+          "(assert (let ((tmp (select a 0)))",
+          "        tmp))"
+        ):
+          solver {
+            val a = smtValue(Array(SInt, Bool))
+            smtAssert(a(0))
+          }
+      test("store"):
+        smtTest(
+          "(declare-const a (Array Int Bool))",
+          "(assert (let ((tmp (store a 0 true)))",
           "        (let ((tmp_0 (select tmp 0)))",
           "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(Array(SInt, Bool))
-            smtAssert(a()(0))
-          }
-      test("store"):
-        smtTest(
-          "(declare-fun a () (Array Int Bool))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (store tmp 0 true)))",
-          "        (let ((tmp_1 (select tmp_0 0)))",
-          "        tmp_1))))"
-        ):
-          solver {
-            val a = SMTFunc(Array(SInt, Bool))
-            val b = a().update(0, true.B)
+            val a = smtValue(Array(SInt, Bool))
+            val b = a.update(0, true.B)
             smtAssert(b(0))
           }
       test("broadcast"):
         smtTest(
-          "(declare-fun a () (Array Int Bool))",
+          "(declare-const a (Array Int Bool))",
           "(assert (let ((tmp ((as const (Array Int Bool)) true)))",
           "        (let ((tmp_0 (select tmp 10)))",
           "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(Array(SInt, Bool))
-            val b = a().broadcast(true.B)
+            val a = smtValue(Array(SInt, Bool))
+            val b = a.broadcast(true.B)
             smtAssert(b(10))
           }
     test("BitVector"):
       test("declare"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))"
+          "(declare-const a (_ BitVec 32))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
+            val a = smtValue(BitVector(true, 32))
           }
       test("==="):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (= tmp #x00000000)))",
-          "        tmp_0)))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp (= a #x00000000)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(a() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(a === 0.B(true, 32))
           }
       test("=/="):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (distinct tmp #x00000000)))",
-          "        tmp_0)))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp (distinct a #x00000000)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(a() =/= 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(a =/= 0.B(true, 32))
           }
       test("+>>"):
         test("Int"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvashr tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvashr a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() +>> 1 === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a +>> 1 === 0.B(true, 32))
             }
         test("SInt"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvashr tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvashr a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() +>> 1.S === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a +>> 1.S === 0.B(true, 32))
             }
       test(">>"):
         test("Int"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvlshr tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvlshr a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() >> 1 === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a >> 1 === 0.B(true, 32))
             }
         test("SInt"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvlshr tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvlshr a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() >> 1.S === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a >> 1.S === 0.B(true, 32))
             }
       test("<<"):
         test("Int"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvshl tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvshl a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() << 1 === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a << 1 === 0.B(true, 32))
             }
         test("SInt"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(assert (let ((tmp (a)))",
-            "        (let ((tmp_0 (bvshl tmp 1)))",
-            "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-            "        tmp_1))))"
+            "(declare-const a (_ BitVec 32))",
+            "(assert (let ((tmp (bvshl a 1)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              smtAssert(a() << 1.S === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              smtAssert(a << 1.S === 0.B(true, 32))
             }
       test("+"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvadd tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvadd a b)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() + b() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a + b === 0.B(true, 32))
           }
       test("*"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvmul tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvmul a b)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() * b() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a * b === 0.B(true, 32))
           }
       test("/"):
         test("sdiv"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(declare-fun b () (_ BitVec 32))",
-            "(assert (let ((tmp (b)))",
-            "        (let ((tmp_0 (a)))",
-            "        (let ((tmp_1 (bvsdiv tmp_0 tmp)))",
-            "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-            "        tmp_2)))))"
+            "(declare-const a (_ BitVec 32))",
+            "(declare-const b (_ BitVec 32))",
+            "(assert (let ((tmp (bvsdiv a b)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              val b = SMTFunc(BitVector(true, 32))
-              smtAssert(a() / b() === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              val b = smtValue(BitVector(true, 32))
+              smtAssert(a / b === 0.B(true, 32))
             }
         test("udiv"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(declare-fun b () (_ BitVec 32))",
-            "(assert (let ((tmp (b)))",
-            "        (let ((tmp_0 (a)))",
-            "        (let ((tmp_1 (bvudiv tmp_0 tmp)))",
-            "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-            "        tmp_2)))))"
+            "(declare-const a (_ BitVec 32))",
+            "(declare-const b (_ BitVec 32))",
+            "(assert (let ((tmp (bvudiv a b)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(false, 32))
-              val b = SMTFunc(BitVector(true, 32))
-              smtAssert(a() / b() === 0.B(true, 32))
+              val a = smtValue(BitVector(false, 32))
+              val b = smtValue(BitVector(true, 32))
+              smtAssert(a / b === 0.B(true, 32))
             }
       test("%"):
         test("srem"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(declare-fun b () (_ BitVec 32))",
-            "(assert (let ((tmp (b)))",
-            "        (let ((tmp_0 (a)))",
-            "        (let ((tmp_1 (bvsrem tmp_0 tmp)))",
-            "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-            "        tmp_2)))))"
+            "(declare-const a (_ BitVec 32))",
+            "(declare-const b (_ BitVec 32))",
+            "(assert (let ((tmp (bvsrem a b)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(true, 32))
-              val b = SMTFunc(BitVector(true, 32))
-              smtAssert(a() % b() === 0.B(true, 32))
+              val a = smtValue(BitVector(true, 32))
+              val b = smtValue(BitVector(true, 32))
+              smtAssert(a % b === 0.B(true, 32))
             }
         test("urem"):
           smtTest(
-            "(declare-fun a () (_ BitVec 32))",
-            "(declare-fun b () (_ BitVec 32))",
-            "(assert (let ((tmp (b)))",
-            "        (let ((tmp_0 (a)))",
-            "        (let ((tmp_1 (bvurem tmp_0 tmp)))",
-            "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-            "        tmp_2)))))"
+            "(declare-const a (_ BitVec 32))",
+            "(declare-const b (_ BitVec 32))",
+            "(assert (let ((tmp (bvurem a b)))",
+            "        (let ((tmp_0 (= tmp #x00000000)))",
+            "        tmp_0)))"
           ):
             solver {
-              val a = SMTFunc(BitVector(false, 32))
-              val b = SMTFunc(BitVector(true, 32))
-              smtAssert(a() % b() === 0.B(true, 32))
+              val a = smtValue(BitVector(false, 32))
+              val b = smtValue(BitVector(true, 32))
+              smtAssert(a % b === 0.B(true, 32))
             }
       test("&"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvand tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvand a b)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert((a() & b()) === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert((a & b) === 0.B(true, 32))
           }
       test("|"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvor tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvor a b)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert((a() | b()) === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert((a | b) === 0.B(true, 32))
           }
       test("^"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvxor tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x00000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvxor a b)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert((a() ^ b()) === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert((a ^ b) === 0.B(true, 32))
           }
       test("++"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (concat tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 #x0000000000000000)))",
-          "        tmp_2)))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (concat a b)))",
+          "        (let ((tmp_0 (= tmp #x0000000000000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert((a() ++ b()) === 0.B(true, 64))
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert((a ++ b) === 0.B(true, 64))
           }
       test("extract"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 ((_ extract 0 0) tmp)))",
-          "        (let ((tmp_1 (= tmp_0 #b0)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp ((_ extract 0 0) a)))",
+          "        (let ((tmp_0 (= tmp #b0)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(a().extract(0, BitVector(true, 1)) === 0.B(true, 1))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(a.extract(0, BitVector(true, 1)) === 0.B(true, 1))
           }
       test("repeat"):
         smtTest(
-          "(declare-fun a () (_ BitVec 4))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 ((_ repeat 8) tmp)))",
-          "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 4))",
+          "(assert (let ((tmp ((_ repeat 8) a)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 4))
-            smtAssert(a().repeat(BitVector(true, 32)) === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 4))
+            smtAssert(a.repeat(BitVector(true, 32)) === 0.B(true, 32))
           }
       test("~"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (bvneg tmp)))",
-          "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp (bvneg a)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(~a() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(~a === 0.B(true, 32))
           }
       test("!"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (bvnot tmp)))",
-          "        (let ((tmp_1 (= tmp_0 #x00000000)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(assert (let ((tmp (bvnot a)))",
+          "        (let ((tmp_0 (= tmp #x00000000)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            smtAssert(!a() === 0.B(true, 32))
+            val a = smtValue(BitVector(true, 32))
+            smtAssert(!a === 0.B(true, 32))
           }
       test("<"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvslt tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvslt a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() < b())
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a < b)
           }
       test("<="):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvsle tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvsle a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() <= b())
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a <= b)
           }
       test(">"):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvsgt tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvsgt a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() > b())
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a > b)
           }
       test(">="):
         smtTest(
-          "(declare-fun a () (_ BitVec 32))",
-          "(declare-fun b () (_ BitVec 32))",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (bvsge tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a (_ BitVec 32))",
+          "(declare-const b (_ BitVec 32))",
+          "(assert (let ((tmp (bvsge a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(BitVector(true, 32))
-            val b = SMTFunc(BitVector(true, 32))
-            smtAssert(a() >= b())
+            val a = smtValue(BitVector(true, 32))
+            val b = smtValue(BitVector(true, 32))
+            smtAssert(a >= b)
           }
     test("Bool"):
       test("declare"):
         smtTest(
-          "(declare-fun a () Bool)"
+          "(declare-const a Bool)"
         ):
           solver {
-            val a = SMTFunc(Bool)
+            val a = smtValue(Bool)
           }
       test("&"):
         smtTest(
-          "(declare-fun a () Bool)",
-          "(declare-fun b () Bool)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (and tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Bool)",
+          "(declare-const b Bool)",
+          "(assert (let ((tmp (and a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(Bool)
-            val b = SMTFunc(Bool)
-            smtAssert(a() & b())
+            val a = smtValue(Bool)
+            val b = smtValue(Bool)
+            smtAssert(a & b)
           }
       test("|"):
         smtTest(
-          "(declare-fun a () Bool)",
-          "(declare-fun b () Bool)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (or tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Bool)",
+          "(declare-const b Bool)",
+          "(assert (let ((tmp (or a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(Bool)
-            val b = SMTFunc(Bool)
-            smtAssert(a() | b())
+            val a = smtValue(Bool)
+            val b = smtValue(Bool)
+            smtAssert(a | b)
           }
       test("!"):
         smtTest(
-          "(declare-fun a () Bool)",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (not tmp)))",
-          "        tmp_0)))"
+          "(declare-const a Bool)",
+          "(assert (let ((tmp (not a)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(Bool)
-            smtAssert(!a())
+            val a = smtValue(Bool)
+            smtAssert(!a)
           }
       test("^"):
         smtTest(
-          "(declare-fun a () Bool)",
-          "(declare-fun b () Bool)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (xor tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Bool)",
+          "(declare-const b Bool)",
+          "(assert (let ((tmp (xor a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(Bool)
-            val b = SMTFunc(Bool)
-            smtAssert(a() ^ b())
+            val a = smtValue(Bool)
+            val b = smtValue(Bool)
+            smtAssert(a ^ b)
           }
       test("==>"):
         smtTest(
-          "(declare-fun a () Bool)",
-          "(declare-fun b () Bool)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (=> tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Bool)",
+          "(declare-const b Bool)",
+          "(assert (let ((tmp (=> a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(Bool)
-            val b = SMTFunc(Bool)
-            smtAssert(a() ==> b())
+            val a = smtValue(Bool)
+            val b = smtValue(Bool)
+            smtAssert(a ==> b)
           }
     test("Int"):
       test("declare"):
         smtTest(
-          "(declare-fun a () Int)"
+          "(declare-const a Int)"
         ):
           solver {
-            val a = SMTFunc(SInt)
+            val a = smtValue(SInt)
           }
       test("==="):
         smtTest(
-          "(declare-fun a () Int)",
-          "(assert (let ((tmp (a)))",
+          "(declare-const a Int)",
+          "(assert (let ((tmp (= a 0)))",
+          "        tmp))"
+        ):
+          solver {
+            val a = smtValue(SInt)
+            smtAssert(a === 0.S)
+          }
+      test("=/="):
+        smtTest(
+          "(declare-const a Int)",
+          "(assert (let ((tmp (distinct a 0)))",
+          "        tmp))"
+        ):
+          solver {
+            val a = smtValue(SInt)
+            smtAssert(a =/= 0.S)
+          }
+      test("+"):
+        smtTest(
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (+ a b)))",
           "        (let ((tmp_0 (= tmp 0)))",
           "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            smtAssert(a() === 0.S)
-          }
-      test("=/="):
-        smtTest(
-          "(declare-fun a () Int)",
-          "(assert (let ((tmp (a)))",
-          "        (let ((tmp_0 (distinct tmp 0)))",
-          "        tmp_0)))"
-        ):
-          solver {
-            val a = SMTFunc(SInt)
-            smtAssert(a() =/= 0.S)
-          }
-      test("+"):
-        smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (+ tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 0)))",
-          "        tmp_2)))))"
-        ):
-          solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() + b() === 0.S)
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a + b === 0.S)
           }
       test("-"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (- tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 0)))",
-          "        tmp_2)))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (- a b)))",
+          "        (let ((tmp_0 (= tmp 0)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() - b() === 0.S)
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a - b === 0.S)
           }
       test("*"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (* tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 0)))",
-          "        tmp_2)))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (* a b)))",
+          "        (let ((tmp_0 (= tmp 0)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() * b() === 0.S)
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a * b === 0.S)
           }
       test("/"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (div tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 0)))",
-          "        tmp_2)))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (div a b)))",
+          "        (let ((tmp_0 (= tmp 0)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() / b() === 0.S)
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a / b === 0.S)
           }
       test("%"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (mod tmp_0 tmp)))",
-          "        (let ((tmp_2 (= tmp_1 0)))",
-          "        tmp_2)))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (mod a b)))",
+          "        (let ((tmp_0 (= tmp 0)))",
+          "        tmp_0)))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() % b() === 0.S)
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a % b === 0.S)
           }
       test(">"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (> tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (> a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() > b())
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a > b)
           }
       test(">="):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (>= tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (>= a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() >= b())
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a >= b)
           }
       test("<"):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (< tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (< a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() < b())
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a < b)
           }
       test("<="):
         smtTest(
-          "(declare-fun a () Int)",
-          "(declare-fun b () Int)",
-          "(assert (let ((tmp (b)))",
-          "        (let ((tmp_0 (a)))",
-          "        (let ((tmp_1 (<= tmp_0 tmp)))",
-          "        tmp_1))))"
+          "(declare-const a Int)",
+          "(declare-const b Int)",
+          "(assert (let ((tmp (<= a b)))",
+          "        tmp))"
         ):
           solver {
-            val a = SMTFunc(SInt)
-            val b = SMTFunc(SInt)
-            smtAssert(a() <= b())
+            val a = smtValue(SInt)
+            val b = smtValue(SInt)
+            smtAssert(a <= b)
           }
     test("SMTFunc"):
       test("declare"):
         smtTest(
-          "(declare-fun f () (Int Bool) Bool)"
+          "(declare-fun f (Int Bool) Bool)"
         ):
           solver {
-            val f = SMTFunc(SMTFunc(Seq(SInt, Bool), Bool))
+            val f = smtValue(SMTFunc(Seq(SInt, Bool), Bool))
           }
       test("apply"):
         smtTest(
-          "(declare-fun f () (Int Bool) Bool)",
+          "(declare-fun f (Int Bool) Bool)",
           "(assert (let ((tmp (f 0 true)))",
-          "        (let ((tmp_0 (tmp)))",
-          "        tmp_0)))"
+          "        tmp))"
         ):
           solver {
-            val f = SMTFunc(SMTFunc(Seq(SInt, Bool), Bool))
+            val f = smtValue(SMTFunc(Seq(SInt, Bool), Bool))
             val a = f(0.S, true.B)
-            smtAssert(a())
+            smtAssert(a)
           }
     test("Sort"):
       test("declare"):
-        smtTest("(declare-fun a () (b Int))"):
+        smtTest(
+          "(declare-sort b 1)",
+          "(declare-const a (b Int))"
+        ):
           solver {
-            val a = SMTFunc(Sort("b", Seq(SInt)))
+            val a = smtValue(Sort("b", Seq(SInt)))
           }


### PR DESCRIPTION
`smtlib2` supports defining values ​​through `declare-const` and defining functions through `declare-fun`. 

Although `smtlib2` supports `zero-ary functions` (e.g. declare-fun a () Int), it can directly treated as a value, named a

However, `circt smt dialect` itself does not support `zero-ary functions`. For example, !smt.func<(), !smt.int> will generate smtlib2 format `(x)` instead of `x`. This is different from the behavior of smtlib2, and the solver will directly report an error.

I define the `smtValue` method in Scala to generate the `declare-const` definition value process, so that the semantics of Scala is the same as `smtlib2`