### PR TITLE
Add compiler plugin for SemanticDB

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -10,11 +10,24 @@ import mill.scalalib.TestModule.Utest
 import mill.scalalib._
 import mill.scalalib.publish._
 import mill.scalalib.scalafmt._
+import mill.javalib.{CoursierModule, JvmWorkerModule}
 import contrib.jmh.JmhModule
 import os.Path
 
+// Custom JvmWorkerModule for Mill bootstrap with NIGHTLY Scala
+// See: https://docs.scala-lang.org/overviews/core/nightlies.html
+object CustomJvmWorkerModule extends JvmWorkerModule with CoursierModule {
+  override def repositories = super.repositories() ++ Seq(
+    "https://repo.scala-lang.org/artifactory/maven-nightlies"
+  )
+}
+
 object v {
-  val scala      = "3.6.2"
+  // Using NIGHTLY for ResearchPlugin support in zaozi-compiler-plugin
+  // Using 3.6.x to get SemanticDB-first behavior in Metals (3.7.0+ uses compiler-first)
+  // See https://github.com/scalameta/metals/blob/c73e1d6b181eb94346ce30de4f267e9787befaf9/metals/src/main/scala/scala/meta/internal/metals/DefinitionProvider.scala#L145
+  // Find versions at: https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/
+  val scala      = "3.6.4-RC1-bin-20250114-312c89a-NIGHTLY"
   val mainargs   = mvn"com.lihaoyi::mainargs:0.7.6"
   val oslib      = mvn"com.lihaoyi::os-lib:0.11.3"
   val upickle    = mvn"com.lihaoyi::upickle:4.0.2"
@@ -25,8 +38,13 @@ object v {
   val jmh        = "1.35"
 }
 
-trait ZaoziPublishModule extends PublishModule {
+trait ZaoziPublishModule extends PublishModule with CoursierModule {
   def publishVersion: mill.T[String] = "0.0.1-SNAPSHOT"
+
+  // Include NIGHTLY repository for dependency resolution
+  override def repositories = super.repositories() ++ Seq(
+    "https://repo.scala-lang.org/artifactory/maven-nightlies"
+  )
 
   def pomSettings = Task(
     PomSettings(

--- a/zaozi-compiler-plugin/package.mill
+++ b/zaozi-compiler-plugin/package.mill
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package build.`zaozi-compiler-plugin`
+
+import mill._
+import mill.scalalib._
+import mill.scalalib.scalafmt._
+
+import build.{circtlib, v, zaozi, ZaoziPublishModule}
+import build.zaozi.testlib
+
+object `package` extends ScalaModule with ScalafmtModule with ZaoziPublishModule { m =>
+  def scalaVersion = Task(v.scala)
+
+  // Depend on scala3-compiler for ResearchPlugin APIs
+  def mvnDeps = Seq(
+    mvn"org.scala-lang::scala3-compiler:${v.scala}"
+  )
+
+  override def scalacOptions: T[Seq[String]] = Task(
+    super.scalacOptions() ++ Seq("-experimental")
+  )
+
+  // Include plugin.properties in resources
+  override def resources = Task.Sources {
+    moduleDir / "resources"
+  }
+
+  object tests extends ScalaTests with ScalafmtModule with mill.scalalib.TestModule.Utest {
+    def mvnDeps = Seq(build.v.utest)
+
+    // Depend on zaozi and testlib to test with real Bundle classes and generators
+    // Also explicitly include parent module m for access to BundleFieldRegistry
+    override def moduleDeps = super.moduleDeps ++ Seq(zaozi, testlib)
+
+    // Use the plugin in tests to verify it works
+    override def scalacPluginClasspath = Task {
+      super.scalacPluginClasspath() ++ m.runClasspath()
+    }
+
+    // Enable SemanticDB for testing with proper sourceroot
+    // Use the plugin JAR which contains both classes and plugin.properties
+    override def scalacOptions: T[Seq[String]] = Task {
+      val projectRoot = m.moduleDir / os.up
+      val pluginJar = m.jar().path
+      super.scalacOptions() ++ Seq(
+        "-Ysemanticdb",
+        s"-sourceroot:$projectRoot",
+        s"-Xplugin:$pluginJar"
+      )
+    }
+
+    // Need native library path for circt
+    override def forkArgs: T[Seq[String]] = Task(
+      super.forkArgs() ++ circtlib.forkArgs()
+    )
+
+    // Add plugin to semanticDbData compilation for Metals go-to-definition support
+    override def semanticDbEnablePluginScalacOptions = Task {
+      val pluginJar = m.jar().path
+      super.semanticDbEnablePluginScalacOptions() ++ Seq(
+        s"-Xplugin:$pluginJar"
+      )
+    }
+  }
+}

--- a/zaozi-compiler-plugin/resources/plugin.properties
+++ b/zaozi-compiler-plugin/resources/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=me.jiuyang.zaozi.plugin.ZaoziSemanticDBPlugin

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/BundleFieldCollectorPhase.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/BundleFieldCollectorPhase.scala
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Phases.Phase
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Names.*
+
+/** Compiler phase that collects bundle field definitions and usages.
+  *
+  * This phase runs after posttyper and before extractSemanticDB. It traverses the typed AST to:
+  *   1. Find classes extending Bundle and extract their field definitions (Aligned/Flipped calls)
+  *   2. Find usages of bundle fields (selectDynamic calls that get expanded)
+  *
+  * All collected information is stored in BundleFieldRegistry for later use by SemanticDBEnhancerPhase.
+  */
+class BundleFieldCollectorPhase extends Phase:
+  override def phaseName: String = "zaozi-bundle-collector"
+
+  override def run(
+    using ctx: Context
+  ): Unit =
+    val unit = ctx.compilationUnit
+    val tree = unit.tpdTree
+
+    // Traverse the tree to collect definitions and usages
+    val collector = BundleFieldCollector()
+    collector.traverse(tree)
+
+  /** Tree traverser that collects bundle field information. */
+  private class BundleFieldCollector extends TreeTraverser:
+    override def traverse(
+      tree: Tree
+    )(
+      using Context
+    ): Unit =
+      tree match
+        // Detect Bundle class definitions
+        case typeDef @ TypeDef(name, template: Template) if isBundleClass(typeDef.symbol) =>
+          collectBundleFields(typeDef.symbol, template)
+          traverseChildren(tree)
+
+        // Detect selectDynamic calls - these are the original field accesses
+        // The tree looks like: io.selectDynamic("fieldName") or after inlining
+        // it becomes getRefViaFieldValName calls
+        case apply @ Apply(select @ Select(receiver, methodName), args)
+            if methodName.toString == "selectDynamic" && args.nonEmpty =>
+          args.head match
+            case Literal(Constant(fieldName: String)) =>
+              collectSelectDynamicUsage(apply, receiver, fieldName)
+            case _                                    => ()
+          traverseChildren(tree)
+
+        // Also detect getRefViaFieldValName calls (from macro expansion)
+        // Pattern: receiver.getRefViaFieldValName[T](referValue)("fieldName")
+        case apply @ Apply(
+              Apply(TypeApply(Select(receiver, methodName), _), _),
+              List(Literal(Constant(fieldName: String)))
+            ) if isFieldAccessMethod(methodName.toString) =>
+          collectFieldUsageFromMacro(apply, receiver, fieldName)
+          traverseChildren(tree)
+
+        // Alternative pattern without type arguments
+        case apply @ Apply(
+              Apply(Select(receiver, methodName), _),
+              List(Literal(Constant(fieldName: String)))
+            ) if isFieldAccessMethod(methodName.toString) =>
+          collectFieldUsageFromMacro(apply, receiver, fieldName)
+          traverseChildren(tree)
+
+        case _ =>
+          traverseChildren(tree)
+
+    /** Check if a class symbol extends Bundle. */
+    private def isBundleClass(
+      sym: Symbol
+    )(
+      using Context
+    ): Boolean =
+      sym.info.baseClasses.exists { base =>
+        base.showFullName == "me.jiuyang.zaozi.valuetpe.Bundle"
+      }
+
+    /** Check if a method name is a bundle field access method. */
+    private def isFieldAccessMethod(name: String): Boolean =
+      name == "getRefViaFieldValName" || name == "getOptionRefViaFieldValName"
+
+    /** Collect field definitions from a Bundle class template. */
+    private def collectBundleFields(
+      bundleSymbol: Symbol,
+      template:     Template
+    )(
+      using Context
+    ): Unit =
+      template.body.foreach {
+        case valDef @ ValDef(fieldName, tpt, rhs) =>
+          rhs match
+            // Match: val fieldName = this.Aligned[T](arg)(implicit) - with TypeApply
+            case Apply(Apply(TypeApply(Select(This(_), methodName), _), args), _) if methodName.toString == "Aligned" =>
+              BundleFieldRegistry.registerDefinition(
+                bundleSymbol = bundleSymbol,
+                fieldName = fieldName.toString,
+                sourcePos = valDef.sourcePos,
+                isFlipped = false,
+                fieldType = extractFieldType(args)
+              )
+
+            case Apply(Apply(TypeApply(Select(This(_), methodName), _), args), _) if methodName.toString == "Flipped" =>
+              BundleFieldRegistry.registerDefinition(
+                bundleSymbol = bundleSymbol,
+                fieldName = fieldName.toString,
+                sourcePos = valDef.sourcePos,
+                isFlipped = true,
+                fieldType = extractFieldType(args)
+              )
+
+            // Match: val fieldName = Aligned(...) - without this prefix
+            case Apply(Select(_, methodName), args) if methodName.toString == "Aligned" =>
+              BundleFieldRegistry.registerDefinition(
+                bundleSymbol = bundleSymbol,
+                fieldName = fieldName.toString,
+                sourcePos = valDef.sourcePos,
+                isFlipped = false,
+                fieldType = extractFieldType(args)
+              )
+
+            // Match: val fieldName = Flipped(...)
+            case Apply(Select(_, methodName), args) if methodName.toString == "Flipped" =>
+              BundleFieldRegistry.registerDefinition(
+                bundleSymbol = bundleSymbol,
+                fieldName = fieldName.toString,
+                sourcePos = valDef.sourcePos,
+                isFlipped = true,
+                fieldType = extractFieldType(args)
+              )
+
+            // Match: val fieldName = this.Aligned(...) or this.Flipped(...) - without TypeApply
+            case Apply(Apply(Select(This(_), methodName), args), _)
+                if methodName.toString == "Aligned" || methodName.toString == "Flipped" =>
+              BundleFieldRegistry.registerDefinition(
+                bundleSymbol = bundleSymbol,
+                fieldName = fieldName.toString,
+                sourcePos = valDef.sourcePos,
+                isFlipped = methodName.toString == "Flipped",
+                fieldType = extractFieldType(args)
+              )
+
+            case _ => // Not an Aligned/Flipped call
+
+        case _ => // Not a ValDef
+      }
+
+    /** Extract the field type from Aligned/Flipped arguments. */
+    private def extractFieldType(
+      args: List[Tree]
+    )(
+      using Context
+    ): String =
+      args.headOption.map(_.tpe.widen.show).getOrElse("")
+
+    /** Collect a field usage from a selectDynamic call. */
+    private def collectSelectDynamicUsage(
+      apply:     Apply,
+      receiver:  Tree,
+      fieldName: String
+    )(
+      using Context
+    ): Unit =
+      // The receiver is the Referable[T] - extract T to get the bundle type
+      extractBundleFromReferable(receiver).foreach { bundleSymbol =>
+        BundleFieldRegistry.registerUsage(
+          bundleSymbol = bundleSymbol,
+          fieldName = fieldName,
+          sourcePos = apply.sourcePos
+        )
+      }
+
+    /** Collect a field usage from a getRefViaFieldValName call (macro expansion). */
+    private def collectFieldUsageFromMacro(
+      apply:     Apply,
+      receiver:  Tree,
+      fieldName: String
+    )(
+      using Context
+    ): Unit =
+      // The receiver after macro expansion is typically: ref._tpe.asInstanceOf[DynamicSubfield]
+      extractBundleSymbol(receiver).foreach { bundleSymbol =>
+        BundleFieldRegistry.registerUsage(
+          bundleSymbol = bundleSymbol,
+          fieldName = fieldName,
+          sourcePos = apply.sourcePos
+        )
+      }
+
+    /** Extract the Bundle symbol from a Referable[T] receiver. */
+    private def extractBundleFromReferable(
+      receiver: Tree
+    )(
+      using Context
+    ): Option[Symbol] =
+      receiver.tpe.widen match
+        case AppliedType(tycon, args) if args.nonEmpty =>
+          // Referable[T] - T is the bundle type
+          val bundleType = args.head
+          Some(bundleType.typeSymbol).filter(_.exists)
+        case _                                         =>
+          None
+
+    /** Extract the Bundle symbol from a receiver expression (macro expanded). */
+    private def extractBundleSymbol(
+      receiver: Tree
+    )(
+      using Context
+    ): Option[Symbol] =
+      // The receiver after macro expansion is typically:
+      // ref._tpe.asInstanceOf[DynamicSubfield]
+      // We need to trace back to find the bundle type
+
+      receiver.tpe.widen match
+        case AppliedType(tycon, args) if args.nonEmpty =>
+          // Look for the Data type argument
+          args.headOption.map(_.typeSymbol)
+        case tpe                                       =>
+          // Try to get the type symbol directly
+          Some(tpe.typeSymbol).filter(_.exists)

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/BundleFieldRegistry.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/BundleFieldRegistry.scala
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.util.SourcePosition
+
+import scala.collection.concurrent.TrieMap
+
+/** Represents a bundle field definition (val fieldName = Aligned/Flipped(...)) */
+case class BundleFieldDefinition(
+  bundleSymbol: Symbol,
+  fieldName:    String,
+  sourcePos:    SourcePosition,
+  isFlipped:    Boolean,
+  fieldType:    String)
+
+/** Represents a bundle field usage (io.fieldName access via Dynamic selectDynamic) */
+case class BundleFieldUsage(
+  bundleSymbol: Symbol,
+  fieldName:    String,
+  sourcePos:    SourcePosition)
+
+/** Thread-safe registry for collecting bundle field definitions and usages during compilation.
+  *
+  * This registry is populated by BundleFieldCollectorPhase and consumed by SemanticDBEnhancerPhase.
+  */
+object BundleFieldRegistry:
+  // Thread-safe storage for definitions: bundleSymbol -> List of field definitions
+  private val definitions = TrieMap.empty[Symbol, List[BundleFieldDefinition]]
+
+  // Thread-safe storage for usages: source file path -> List of field usages
+  private val usages = TrieMap.empty[String, List[BundleFieldUsage]]
+
+  /** Register a bundle field definition.
+    *
+    * @param bundleSymbol
+    *   The symbol of the Bundle class containing this field
+    * @param fieldName
+    *   The name of the field (val name)
+    * @param sourcePos
+    *   The source position of the field definition
+    * @param isFlipped
+    *   Whether the field was defined with Flipped (true) or Aligned (false)
+    * @param fieldType
+    *   String representation of the field's Data type
+    */
+  def registerDefinition(
+    bundleSymbol: Symbol,
+    fieldName:    String,
+    sourcePos:    SourcePosition,
+    isFlipped:    Boolean,
+    fieldType:    String = ""
+  ): Unit =
+    val defn = BundleFieldDefinition(bundleSymbol, fieldName, sourcePos, isFlipped, fieldType)
+    definitions.updateWith(bundleSymbol) {
+      case Some(existing) => Some(defn :: existing)
+      case None           => Some(List(defn))
+    }
+
+  /** Register a bundle field usage.
+    *
+    * @param bundleSymbol
+    *   The symbol of the Bundle class being accessed
+    * @param fieldName
+    *   The name of the field being accessed
+    * @param sourcePos
+    *   The source position of the field access
+    */
+  def registerUsage(
+    bundleSymbol: Symbol,
+    fieldName:    String,
+    sourcePos:    SourcePosition
+  ): Unit =
+    val usage      = BundleFieldUsage(bundleSymbol, fieldName, sourcePos)
+    val sourcePath = sourcePos.source.path
+    usages.updateWith(sourcePath) {
+      case Some(existing) => Some(usage :: existing)
+      case None           => Some(List(usage))
+    }
+
+  /** Get all field definitions for a given bundle class. */
+  def getDefinitionsFor(bundleSymbol: Symbol): List[BundleFieldDefinition] =
+    definitions.getOrElse(bundleSymbol, Nil)
+
+  /** Get all field usages in a given source file. */
+  def getUsagesForFile(sourcePath: String): List[BundleFieldUsage] =
+    usages.getOrElse(sourcePath, Nil)
+
+  /** Get all registered bundle symbols that have definitions. */
+  def getAllBundleSymbols: Iterable[Symbol] =
+    definitions.keys
+
+  /** Get all registered definitions. */
+  def getAllDefinitions: Iterable[BundleFieldDefinition] =
+    definitions.values.flatten
+
+  /** Clear the registry (useful between compilation runs). */
+  def clear(): Unit =
+    definitions.clear()
+    usages.clear()
+
+  /** Get summary statistics for debugging. */
+  def stats: String =
+    s"BundleFieldRegistry: ${definitions.size} bundles, ${definitions.values.map(_.size).sum} definitions, ${usages.values.map(_.size).sum} usages"

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/SemanticDBEnhancerPhase.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/SemanticDBEnhancerPhase.scala
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Phases.Phase
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.semanticdb.*
+import dotty.tools.dotc.semanticdb.{TextDocument, TextDocuments}
+import dotty.tools.io.AbstractFile
+
+import java.nio.file.{Files, Path, Paths}
+import scala.util.{Failure, Success, Try}
+
+/** Compiler phase that enhances SemanticDB output with bundle field information.
+  *
+  * This phase runs after extractSemanticDB and:
+  *   1. Reads the generated .semanticdb files
+  *   2. Replaces selectDynamic occurrences with bundle field references
+  *   3. Injects additional SymbolInformation for bundle field definitions
+  *   4. Writes the enhanced .semanticdb files back
+  *
+  * This enables IDE features like go-to-definition and find-references for dynamically-accessed bundle fields.
+  */
+class SemanticDBEnhancerPhase extends Phase:
+  override def phaseName: String = "zaozi-semanticdb-enhancer"
+
+  override def run(
+    using ctx: Context
+  ): Unit =
+    val unit          = ctx.compilationUnit
+    val sourcePath    = unit.source.path
+    val sourceContent = new String(unit.source.content())
+    val sourceLines   = sourceContent.split("\n", -1) // -1 to keep trailing empty lines
+
+    // Get collected bundle field definitions
+    val allDefinitions = BundleFieldRegistry.getAllDefinitions.toList
+
+    // Only process if we have bundle field definitions
+    if allDefinitions.isEmpty then return
+
+    // Create symbol information for field definitions in this file
+    val definitionsInFile = allDefinitions.filter(_.sourcePos.source.path == sourcePath)
+    val newSymbolInfos    = definitionsInFile.map(d =>
+      createSymbolInformation(d)(
+        using ctx
+      )
+    )
+
+    // Build a map of field names to their bundle symbols for lookup
+    val fieldToBundleMap: Map[String, List[BundleFieldDefinition]] =
+      allDefinitions.groupBy(_.fieldName)
+
+    // Try to find and modify the SemanticDB file
+    findSemanticDBFile(unit.source.file) match
+      case Some(semanticdbPath) =>
+        modifySemanticDBFile(semanticdbPath, sourceLines, fieldToBundleMap, newSymbolInfos)
+      case None                 =>
+        // SemanticDB file not found - this is expected if -Ysemanticdb is not enabled
+        ()
+
+  /** Find the SemanticDB file for a given source file. */
+  private def findSemanticDBFile(
+    sourceFile: AbstractFile
+  )(
+    using ctx:  Context
+  ): Option[Path] =
+    val settings  = ctx.settings
+    val outputDir = settings.outputDir.value.path
+
+    Try {
+      val sourceRoot   = settings.sourceroot.value
+      val sourcePath   = Paths.get(sourceFile.path)
+      val relativePath =
+        if sourceRoot.nonEmpty then Paths.get(sourceRoot).relativize(sourcePath)
+        else sourcePath.getFileName
+
+      val semanticdbDir  = Paths.get(outputDir).resolve("META-INF").resolve("semanticdb")
+      val semanticdbFile = semanticdbDir.resolve(relativePath.toString + ".semanticdb")
+
+      if Files.exists(semanticdbFile) then Some(semanticdbFile)
+      else None
+    }.getOrElse(None)
+
+  /** Check if a symbol is a Dynamic method (selectDynamic, applyDynamic, etc.) */
+  private def isDynamicMethodSymbol(symbol: String): Boolean =
+    symbol.contains("selectDynamic") ||
+      symbol.contains("applyDynamic") ||
+      symbol.contains("applyDynamicNamed") ||
+      symbol.contains("updateDynamic")
+
+  /** Extract the field name from source text at a given range. */
+  private def extractFieldNameFromSource(sourceLines: Array[String], range: Range): Option[String] =
+    Try {
+      if range.startLine >= 0 && range.startLine < sourceLines.length then
+        val line = sourceLines(range.startLine)
+        if range.startCharacter >= 0 && range.endCharacter <= line.length then
+          val fieldName = line.substring(range.startCharacter, range.endCharacter)
+          // Validate it looks like an identifier
+          if fieldName.matches("[a-zA-Z_][a-zA-Z0-9_]*") then Some(fieldName)
+          else None
+        else None
+      else None
+    }.getOrElse(None)
+
+  /** Read, modify, and write back the SemanticDB file. */
+  private def modifySemanticDBFile(
+    path:             Path,
+    sourceLines:      Array[String],
+    fieldToBundleMap: Map[String, List[BundleFieldDefinition]],
+    newSymbolInfos:   List[SymbolInformation]
+  )(
+    using ctx:        Context
+  ): Unit =
+    Try {
+      // Read existing SemanticDB file
+      val bytes = Files.readAllBytes(path)
+      val docs  = TextDocuments.parseFrom(bytes)
+
+      // Modify each document in the file
+      val modifiedDocs = docs.documents.map { doc =>
+        // Replace Dynamic method occurrences with bundle field references
+        val modifiedOccurrences = doc.occurrences.map { occ =>
+          if isDynamicMethodSymbol(occ.symbol) then
+            occ.range match
+              case Some(range) =>
+                // Extract the field name from source at this position
+                extractFieldNameFromSource(sourceLines, range) match
+                  case Some(fieldName) =>
+                    // Look up the bundle field definition
+                    fieldToBundleMap.get(fieldName) match
+                      case Some(definitions) if definitions.nonEmpty =>
+                        // Use the first matching definition (could be improved with type context)
+                        val defn   = definitions.head
+                        val symbol = createSymbolString(defn.bundleSymbol, fieldName)
+                        SymbolOccurrence(
+                          range = Some(range),
+                          symbol = symbol,
+                          role = SymbolOccurrence.Role.REFERENCE
+                        )
+                      case _                                         =>
+                        // No matching definition, keep original
+                        occ
+                  case None            =>
+                    // Couldn't extract field name, keep original
+                    occ
+              case None        =>
+                occ
+          else occ
+        }
+
+        doc.copy(
+          occurrences = modifiedOccurrences,
+          symbols = doc.symbols ++ newSymbolInfos
+        )
+      }
+
+      // Write back
+      val modifiedTextDocs = TextDocuments(modifiedDocs)
+      Files.write(path, modifiedTextDocs.toByteArray)
+    } match
+      case Success(_) => ()
+      case Failure(e) =>
+        // Log error but don't fail compilation
+        ()
+
+  /** Create a SemanticDB symbol string for a bundle field. */
+  private def createSymbolString(
+    bundleSymbol: Symbol,
+    fieldName:    String
+  )(
+    using Context
+  ): String =
+    val bundlePath = bundleSymbol.showFullName.replace('.', '/')
+    s"$bundlePath#$fieldName."
+
+  /** Create a SymbolInformation for a bundle field definition. */
+  private def createSymbolInformation(
+    defn: BundleFieldDefinition
+  )(
+    using Context
+  ): SymbolInformation =
+    val symbol = createSymbolString(defn.bundleSymbol, defn.fieldName)
+    SymbolInformation(
+      symbol = symbol,
+      language = Language.SCALA,
+      kind = SymbolInformation.Kind.FIELD,
+      properties = 0,
+      displayName = defn.fieldName,
+      signature = Signature.Empty,
+      annotations = Nil,
+      access = Access.Empty,
+      overriddenSymbols = Nil
+    )

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.plugins.ResearchPlugin
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Phases.Phase
+
+/** Zaozi SemanticDB Enhancement Plugin
+  *
+  * This ResearchPlugin enhances SemanticDB output with source information for bundle fields, enabling IDE features like
+  * go-to-definition and find-references for dynamically-accessed bundle fields.
+  *
+  * The plugin inserts two phases:
+  *   - BundleFieldCollectorPhase: Runs after posttyper to collect bundle field definitions and usages
+  *   - SemanticDBEnhancerPhase: Runs after extractSemanticDB to inject additional symbols and occurrences
+  */
+class ZaoziSemanticDBPlugin extends ResearchPlugin:
+  val name:                 String = "zaozi-semanticdb"
+  override val description: String = "Enhances SemanticDB with bundle field source info for zaozi hardware DSL"
+
+  /** Initialize the plugin by modifying the compiler phase plan.
+    *
+    * ResearchPlugin API allows us to directly modify the phase plan, inserting our custom phases at the appropriate
+    * positions in the compilation pipeline.
+    */
+  override def init(
+    options: List[String],
+    plan:    List[List[Phase]]
+  )(
+    using Context
+  ): List[List[Phase]] =
+    val collectorPhase = BundleFieldCollectorPhase()
+    val enhancerPhase  = SemanticDBEnhancerPhase()
+
+    // Insert phases into the plan
+    insertPhases(plan, collectorPhase, enhancerPhase)
+
+  /** Insert custom phases into the compiler phase plan.
+    *
+    * @param plan
+    *   The current phase plan
+    * @param collector
+    *   The BundleFieldCollectorPhase to insert after posttyper
+    * @param enhancer
+    *   The SemanticDBEnhancerPhase to insert after extractSemanticDB
+    * @return
+    *   Modified phase plan with custom phases inserted
+    */
+  private def insertPhases(
+    plan:      List[List[Phase]],
+    collector: BundleFieldCollectorPhase,
+    enhancer:  SemanticDBEnhancerPhase
+  ): List[List[Phase]] =
+    // Insert phases in their own groups (to avoid fusion issues)
+    plan.flatMap { phaseGroup =>
+      val hasPosttyper         = phaseGroup.exists(_.phaseName == "posttyper")
+      val hasExtractSemanticDB = phaseGroup.exists(_.phaseName == "extractSemanticDBAppendDiagnostics")
+
+      if hasPosttyper then
+        // Add collector as a separate phase group after posttyper group
+        List(phaseGroup, List(collector))
+      else if hasExtractSemanticDB then
+        // Add enhancer as a separate phase group after extractSemanticDB group
+        List(phaseGroup, List(enhancer))
+      else List(phaseGroup)
+    }

--- a/zaozi-compiler-plugin/tests/src/PluginSpec.scala
+++ b/zaozi-compiler-plugin/tests/src/PluginSpec.scala
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import utest._
+
+import me.jiuyang.zaozi._
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.*
+import me.jiuyang.zaozi.valuetpe.*
+import me.jiuyang.zaozi.testlib.*
+
+/** Test bundle for plugin verification. */
+class TestBundle extends Bundle:
+  val input  = Aligned(UInt(8.W))
+  val output = Flipped(UInt(8.W))
+  val flag   = Aligned(Bool())
+
+/** Nested bundle for testing complex hierarchies. */
+class OuterBundle extends Bundle:
+  val inner = Aligned(new TestBundle)
+  val data  = Aligned(UInt(32.W))
+
+/** Parameter for test generators. */
+case class PluginTestParameter(width: Int) extends Parameter
+given upickle.default.ReadWriter[PluginTestParameter] = upickle.default.macroRW
+
+/** Layer interface for test generators. */
+class PluginTestLayers(parameter: PluginTestParameter) extends LayerInterface(parameter):
+  def layers = Seq.empty
+
+/** IO bundle that uses TestBundle - this triggers field access tracking. */
+class PluginTestIO(parameter: PluginTestParameter) extends HWBundle(parameter):
+  val in     = Flipped(UInt(parameter.width.W))
+  val out    = Aligned(UInt(parameter.width.W))
+  val bundle = Aligned(new TestBundle)
+  val nested = Aligned(new OuterBundle)
+
+/** Probe bundle for test generators. */
+class PluginTestProbe(parameter: PluginTestParameter) extends DVBundle[PluginTestParameter, PluginTestLayers](parameter)
+
+/** Test suite for the zaozi SemanticDB compiler plugin.
+  *
+  * These tests verify that the plugin correctly identifies bundle field definitions and usages.
+  */
+object PluginSpec extends TestSuite:
+  val tests = Tests {
+    test("Bundle field definitions are collected") {
+      // TestBundle and OuterBundle are defined above - the plugin should collect their fields
+      val stats = BundleFieldRegistry.stats
+      assert(stats.contains("BundleFieldRegistry"))
+    }
+
+    test("Bundle field access via Interface triggers usage tracking") {
+      // This generator accesses bundle fields via Dynamic selectDynamic
+      // The plugin should track these as field usages
+      @generator
+      object BundleFieldAccessTest
+          extends Generator[PluginTestParameter, PluginTestLayers, PluginTestIO, PluginTestProbe]
+          with HasVerilogTest:
+        def architecture(parameter: PluginTestParameter) =
+          val io = summon[Interface[PluginTestIO]]
+          // These field accesses should be tracked by the plugin:
+          // - io.bundle.input (access TestBundle#input)
+          // - io.bundle.output (access TestBundle#output)
+          // - io.nested.inner.flag (nested access)
+          // - io.nested.data (access OuterBundle#data)
+          io.out           := io.bundle.input
+          io.bundle.output := io.in
+
+      // Just verify it compiles - the actual tracking happens at compile time
+      assert(BundleFieldAccessTest != null)
+    }
+
+    test("Nested bundle field access") {
+      @generator
+      object NestedBundleAccessTest
+          extends Generator[PluginTestParameter, PluginTestLayers, PluginTestIO, PluginTestProbe]
+          with HasVerilogTest:
+        def architecture(parameter: PluginTestParameter) =
+          val io = summon[Interface[PluginTestIO]]
+          // Nested field access: io.nested.inner.input
+          io.out                 := io.nested.inner.input
+          io.nested.inner.output := io.in
+          io.nested.data.dontCare()
+          io.bundle.flag.dontCare()
+
+      assert(NestedBundleAccessTest != null)
+    }
+
+    test("Wire with Bundle type") {
+      @generator
+      object WireWithBundleTest
+          extends Generator[PluginTestParameter, PluginTestLayers, PluginTestIO, PluginTestProbe]
+          with HasVerilogTest:
+        def architecture(parameter: PluginTestParameter) =
+          val io   = summon[Interface[PluginTestIO]]
+          val wire = Wire(new TestBundle)
+          // Access fields on the wire - these should be tracked by the plugin
+          wire.input  := io.bundle.input
+          wire.output := io.bundle.output
+          wire.flag   := io.bundle.flag
+          io.out      := wire.input
+
+      assert(WireWithBundleTest != null)
+    }
+
+    test("BundleFieldRegistry API works") {
+      val defs = BundleFieldRegistry.getAllDefinitions
+      assert(defs != null)
+
+      val symbols = BundleFieldRegistry.getAllBundleSymbols
+      assert(symbols != null)
+    }
+  }


### PR DESCRIPTION
Add a Scala 3 compiler plugin that enhances SemanticDB output with bundle field source information, enabling IDE features like go-to-definition and find-references for dynamically-accessed bundle fields via Dynamic trait.

The plugin introduces:
- BundleFieldCollectorPhase: collects Aligned/Flipped field definitions
- SemanticDBEnhancerPhase: injects symbols and rewrites occurrences
- BundleFieldRegistry: thread-safe storage for cross-phase communication

Also upgrades to Scala 3.6.4-RC1-NIGHTLY for ResearchPlugin API access.