### PR TITLE
fix(zaozi): allow mixed Referable operands in operators

### DIFF
--- a/doc/rationales.typ
+++ b/doc/rationales.typ
@@ -1,0 +1,5 @@
+= Rationales
+
+== Operand-Agnostic Domain APIs
+
+Domain-level API bundles such as `UIntApi`, `SIntApi`, `BitsApi`, and `BoolApi` describe which operations exist for a data domain, not the concrete shapes of the operands in a particular call. Operand roles belong only to the operators that need them: unary operators quantify the receiver, binary operators quantify `LHS` and `RHS` at the method level, and shift or indexing operators take their concrete argument forms at the method level as well. This keeps capability requirements honest and stable in generic code, allows different `Referable` implementations to compose naturally, and makes the type API reflect semantic structure instead of encoding call-site accidents into the trait shape.

--- a/stdlib/src/VecUtils.scala
+++ b/stdlib/src/VecUtils.scala
@@ -22,7 +22,7 @@ trait VecUtilsApi:
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext,
-      VecApi[E, V, R]
+      VecApi[E, V]
     ): IndexedSeq[Ref[E]]
 
   extension [E <: Data](seq: Seq[Referable[E]])

--- a/stdlib/src/default/TypeUtils.scala
+++ b/stdlib/src/default/TypeUtils.scala
@@ -23,13 +23,13 @@ given TypeUtilsApi with
       sourcecode.Name.Machine,
       InstanceContext
     ): Propagated[R, Bits] = (ref.getType match
-      case _: Bool   => summon[AsBits[Bool, Referable[Bool]]].asBits(ref.asInstanceOf[Referable[Bool]])
-      case _: Bundle => summon[AsBits[Bundle, Referable[Bundle]]].asBits(ref.asInstanceOf[Referable[Bundle]])
-      case _: Record => summon[AsBits[Record, Referable[Record]]].asBits(ref.asInstanceOf[Referable[Record]])
-      case _: SInt   => summon[AsBits[SInt, Referable[SInt]]].asBits(ref.asInstanceOf[Referable[SInt]])
-      case _: UInt   => summon[AsBits[UInt, Referable[UInt]]].asBits(ref.asInstanceOf[Referable[UInt]])
+      case _: Bool   => summon[AsBits[Bool]].asBits(ref.asInstanceOf[Referable[Bool]])
+      case _: Bundle => summon[AsBits[Bundle]].asBits(ref.asInstanceOf[Referable[Bundle]])
+      case _: Record => summon[AsBits[Record]].asBits(ref.asInstanceOf[Referable[Record]])
+      case _: SInt   => summon[AsBits[SInt]].asBits(ref.asInstanceOf[Referable[SInt]])
+      case _: UInt   => summon[AsBits[UInt]].asBits(ref.asInstanceOf[Referable[UInt]])
       case _: Vec[?] =>
-        summon[AsBits[Vec[Bool], Referable[Vec[Bool]]]].asBits(
+        summon[AsBits[Vec[Bool]]].asBits(
           // we don't care about the type parameter of Vec here
           ref.asInstanceOf[Referable[Vec[Bool]]]
         )

--- a/stdlib/src/default/TypeUtils.scala
+++ b/stdlib/src/default/TypeUtils.scala
@@ -23,13 +23,13 @@ given TypeUtilsApi with
       sourcecode.Name.Machine,
       InstanceContext
     ): Propagated[R, Bits] = (ref.getType match
-      case _: Bool   => given_BoolApi_R.asBits(ref.asInstanceOf[Referable[Bool]])
-      case _: Bundle => given_BundleApi_T_R.asBits(ref.asInstanceOf[Referable[Bundle]])
-      case _: Record => given_RecordApi_T_R.asBits(ref.asInstanceOf[Referable[Record]])
-      case _: SInt   => given_SIntApi_R.asBits(ref.asInstanceOf[Referable[SInt]])
-      case _: UInt   => given_UIntApi_R.asBits(ref.asInstanceOf[Referable[UInt]])
+      case _: Bool   => summon[AsBits[Bool, Referable[Bool]]].asBits(ref.asInstanceOf[Referable[Bool]])
+      case _: Bundle => summon[AsBits[Bundle, Referable[Bundle]]].asBits(ref.asInstanceOf[Referable[Bundle]])
+      case _: Record => summon[AsBits[Record, Referable[Record]]].asBits(ref.asInstanceOf[Referable[Record]])
+      case _: SInt   => summon[AsBits[SInt, Referable[SInt]]].asBits(ref.asInstanceOf[Referable[SInt]])
+      case _: UInt   => summon[AsBits[UInt, Referable[UInt]]].asBits(ref.asInstanceOf[Referable[UInt]])
       case _: Vec[?] =>
-        given_VecApi_E_V_R.asBits(
+        summon[AsBits[Vec[Bool], Referable[Vec[Bool]]]].asBits(
           // we don't care about the type parameter of Vec here
           ref.asInstanceOf[Referable[Vec[Bool]]]
         )

--- a/stdlib/src/default/VecUtils.scala
+++ b/stdlib/src/default/VecUtils.scala
@@ -22,7 +22,7 @@ given VecUtilsApi with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext,
-      VecApi[E, V, R]
+      VecApi[E, V]
     ): IndexedSeq[Ref[E]] =
       new IndexedSeq[Ref[E]]:
         def length:          Int    = ref.length

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -564,10 +564,10 @@ trait XorR[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Add[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Add[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def +(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -577,10 +577,10 @@ trait Add[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Sub[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Sub[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def -(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -590,10 +590,10 @@ trait Sub[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Mul[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Mul[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def *(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -603,10 +603,10 @@ trait Mul[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Div[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Div[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def /(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -616,10 +616,10 @@ trait Div[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Rem[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Rem[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def %(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -629,10 +629,10 @@ trait Rem[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Lt[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Lt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def <(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -642,10 +642,10 @@ trait Lt[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Leq[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Leq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def <=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -655,10 +655,10 @@ trait Leq[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Gt[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Gt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def >(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -668,10 +668,10 @@ trait Gt[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Geq[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Geq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def >=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -681,10 +681,10 @@ trait Geq[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Eq[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Eq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def ===(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -694,10 +694,10 @@ trait Eq[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Neq[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Neq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def =/=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -707,10 +707,10 @@ trait Neq[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait And[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait And[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def &(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -720,10 +720,10 @@ trait And[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Or[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Or[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def |(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -733,10 +733,10 @@ trait Or[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Xor[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Xor[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def ^(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -746,10 +746,10 @@ trait Xor[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Cat[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Cat[D <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
+  extension (ref: LHS)
     def ##(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -886,69 +886,69 @@ trait GetLength[E <: Data, V <: Vec[E], R <: Referable[V]]:
       Context
     ): Int
 
-trait BitsApi[R <: Referable[Bits]]
-    extends AsSInt[Bits, R]
-    with AsUInt[Bits, R]
-    with AsBool[Bits, R]
-    with AsBundle[Bits, R]
-    with AsRecord[Bits, R]
-    with AsVec[Bits, R]
-    with Not[Bits, Bits, R]
-    with AndR[Bits, Bool, R]
-    with OrR[Bits, Bool, R]
-    with XorR[Bits, Bool, R]
-    with Eq[Bits, Bool, R]
-    with Neq[Bits, Bool, R]
-    with And[Bits, Bits, R]
-    with Or[Bits, Bits, R]
-    with Xor[Bits, Bits, R]
-    with Cat[Bits, R]
-    with Shl[Bits, Int | Referable[UInt], Bits, R]
-    with Shr[Bits, Int | Referable[UInt], Bits, R]
-    with Head[Bits, Int, Bits, R]
-    with Tail[Bits, Int, Bits, R]
-    with Pad[Bits, Int, Bits, R]
-    with ExtractElement[Bits, Bool, R, Int]
-    with ExtractRange[Bits, Bits, R, Int]
+trait BitsApi[LHS <: Referable[Bits], RHS <: Referable[Bits]]
+    extends AsSInt[Bits, LHS]
+    with AsUInt[Bits, LHS]
+    with AsBool[Bits, LHS]
+    with AsBundle[Bits, LHS]
+    with AsRecord[Bits, LHS]
+    with AsVec[Bits, LHS]
+    with Not[Bits, Bits, LHS]
+    with AndR[Bits, Bool, LHS]
+    with OrR[Bits, Bool, LHS]
+    with XorR[Bits, Bool, LHS]
+    with Eq[Bits, Bool, LHS, RHS]
+    with Neq[Bits, Bool, LHS, RHS]
+    with And[Bits, Bits, LHS, RHS]
+    with Or[Bits, Bits, LHS, RHS]
+    with Xor[Bits, Bits, LHS, RHS]
+    with Cat[Bits, LHS, RHS]
+    with Shl[Bits, Int | Referable[UInt], Bits, LHS]
+    with Shr[Bits, Int | Referable[UInt], Bits, LHS]
+    with Head[Bits, Int, Bits, LHS]
+    with Tail[Bits, Int, Bits, LHS]
+    with Pad[Bits, Int, Bits, LHS]
+    with ExtractElement[Bits, Bool, LHS, Int]
+    with ExtractRange[Bits, Bits, LHS, Int]
 
-trait BoolApi[R <: Referable[Bool]]
-    extends AsBits[Bool, R]
-    with Neg[Bool, Bool, R]
-    with Eq[Bool, Bool, R]
-    with Neq[Bool, Bool, R]
-    with And[Bool, Bool, R]
-    with Or[Bool, Bool, R]
-    with Xor[Bool, Bool, R]
-    with Mux[Bool, R]
-trait UIntApi[R <: Referable[UInt]]
-    extends AsBits[UInt, R]
-    with Add[UInt, UInt, R]
-    with Sub[UInt, UInt, R]
-    with Mul[UInt, UInt, R]
-    with Div[UInt, UInt, R]
-    with Rem[UInt, UInt, R]
-    with Lt[UInt, Bool, R]
-    with Leq[UInt, Bool, R]
-    with Gt[UInt, Bool, R]
-    with Geq[UInt, Bool, R]
-    with Eq[UInt, Bool, R]
-    with Neq[UInt, Bool, R]
-    with Shl[UInt, Int | Referable[UInt], UInt, R]
-    with Shr[UInt, Int | Referable[UInt], UInt, R]
-trait SIntApi[R <: Referable[SInt]]
-    extends AsBits[SInt, R]
-    with Add[SInt, SInt, R]
-    with Sub[SInt, SInt, R]
-    with Mul[SInt, SInt, R]
-    with Div[SInt, SInt, R]
-    with Rem[SInt, SInt, R]
-    with Lt[SInt, Bool, R]
-    with Leq[SInt, Bool, R]
-    with Gt[SInt, Bool, R]
-    with Geq[SInt, Bool, R]
-    with Neq[SInt, Bool, R]
-    with Shl[SInt, Int | Referable[UInt], SInt, R]
-    with Shr[SInt, Int | Referable[UInt], SInt, R]
+trait BoolApi[LHS <: Referable[Bool], RHS <: Referable[Bool]]
+    extends AsBits[Bool, LHS]
+    with Neg[Bool, Bool, LHS]
+    with Eq[Bool, Bool, LHS, RHS]
+    with Neq[Bool, Bool, LHS, RHS]
+    with And[Bool, Bool, LHS, RHS]
+    with Or[Bool, Bool, LHS, RHS]
+    with Xor[Bool, Bool, LHS, RHS]
+    with Mux[Bool, LHS]
+trait UIntApi[LHS <: Referable[UInt], RHS <: Referable[UInt]]
+    extends AsBits[UInt, LHS]
+    with Add[UInt, UInt, LHS, RHS]
+    with Sub[UInt, UInt, LHS, RHS]
+    with Mul[UInt, UInt, LHS, RHS]
+    with Div[UInt, UInt, LHS, RHS]
+    with Rem[UInt, UInt, LHS, RHS]
+    with Lt[UInt, Bool, LHS, RHS]
+    with Leq[UInt, Bool, LHS, RHS]
+    with Gt[UInt, Bool, LHS, RHS]
+    with Geq[UInt, Bool, LHS, RHS]
+    with Eq[UInt, Bool, LHS, RHS]
+    with Neq[UInt, Bool, LHS, RHS]
+    with Shl[UInt, Int | Referable[UInt], UInt, LHS]
+    with Shr[UInt, Int | Referable[UInt], UInt, LHS]
+trait SIntApi[LHS <: Referable[SInt], RHS <: Referable[SInt]]
+    extends AsBits[SInt, LHS]
+    with Add[SInt, SInt, LHS, RHS]
+    with Sub[SInt, SInt, LHS, RHS]
+    with Mul[SInt, SInt, LHS, RHS]
+    with Div[SInt, SInt, LHS, RHS]
+    with Rem[SInt, SInt, LHS, RHS]
+    with Lt[SInt, Bool, LHS, RHS]
+    with Leq[SInt, Bool, LHS, RHS]
+    with Gt[SInt, Bool, LHS, RHS]
+    with Geq[SInt, Bool, LHS, RHS]
+    with Neq[SInt, Bool, LHS, RHS]
+    with Shl[SInt, Int | Referable[UInt], SInt, LHS]
+    with Shr[SInt, Int | Referable[UInt], SInt, LHS]
 
 trait BundleApi[T <: Bundle | ProbeBundle, R <: Referable[T]] extends AsBits[T, R]
 

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -362,8 +362,8 @@ trait ConstructorApi:
     ): Const[Bool]
 end ConstructorApi
 
-trait AsBits[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsBits[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asBits(
       using Arena,
       Context,
@@ -373,8 +373,8 @@ trait AsBits[D <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Propagated[R, Bits]
-trait AsBool[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsBool[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asBool(
       using Arena,
       Context,
@@ -384,8 +384,8 @@ trait AsBool[D <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Propagated[R, Bool]
-trait AsSInt[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsSInt[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asSInt(
       using Arena,
       Context,
@@ -395,8 +395,8 @@ trait AsSInt[D <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Propagated[R, SInt]
-trait AsUInt[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsUInt[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asUInt(
       using Arena,
       Context,
@@ -407,8 +407,8 @@ trait AsUInt[D <: Data, R <: Referable[D]]:
       InstanceContext
     ): Propagated[R, UInt]
 
-trait AsBundle[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsBundle[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asBundle[T <: Bundle](
       tpe: T
     )(
@@ -421,8 +421,8 @@ trait AsBundle[D <: Data, R <: Referable[D]]:
       InstanceContext
     ): Propagated[R, T]
 
-trait AsRecord[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsRecord[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asRecord[T <: Record](
       tpe: T
     )(
@@ -435,8 +435,8 @@ trait AsRecord[D <: Data, R <: Referable[D]]:
       InstanceContext
     ): Propagated[R, T]
 
-trait AsVec[D <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AsVec[D <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def asVec[E <: Data](
       tpe: E
     )(
@@ -498,8 +498,8 @@ trait MonoConnect[D <: Data, SRC <: Referable[D], SINK <: Writable[D]]:
       sourcecode.File,
       sourcecode.Line
     ): Unit
-trait Cvt[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Cvt[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def zext(
       using Arena,
       Context,
@@ -509,8 +509,8 @@ trait Cvt[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Neg[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Neg[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def unary_!(
       using Arena,
       Context,
@@ -520,8 +520,8 @@ trait Neg[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Not[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Not[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def unary_~(
       using Arena,
       Context,
@@ -531,8 +531,8 @@ trait Not[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait AndR[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait AndR[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def andR(
       using Arena,
       Context,
@@ -542,8 +542,8 @@ trait AndR[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait OrR[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait OrR[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def orR(
       using Arena,
       Context,
@@ -553,8 +553,8 @@ trait OrR[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait XorR[D <: Data, RET <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait XorR[D <: Data, RET <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def xorR(
       using Arena,
       Context,
@@ -564,9 +564,9 @@ trait XorR[D <: Data, RET <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Add[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def +(
+trait Add[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def +[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -577,9 +577,9 @@ trait Add[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Sub[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def -(
+trait Sub[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def -[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -590,9 +590,9 @@ trait Sub[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Mul[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def *(
+trait Mul[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def *[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -603,9 +603,9 @@ trait Mul[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Div[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def /(
+trait Div[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def /[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -616,9 +616,9 @@ trait Div[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Rem[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def %(
+trait Rem[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def %[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -629,9 +629,9 @@ trait Rem[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Lt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def <(
+trait Lt[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def <[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -642,9 +642,9 @@ trait Lt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Leq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def <=(
+trait Leq[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def <=[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -655,9 +655,9 @@ trait Leq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Gt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def >(
+trait Gt[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def >[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -668,9 +668,9 @@ trait Gt[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Geq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def >=(
+trait Geq[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def >=[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -681,9 +681,9 @@ trait Geq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Eq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def ===(
+trait Eq[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def ===[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -694,9 +694,9 @@ trait Eq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Neq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def =/=(
+trait Neq[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def =/=[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -707,9 +707,9 @@ trait Neq[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait And[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def &(
+trait And[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def &[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -720,9 +720,9 @@ trait And[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Or[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def |(
+trait Or[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def |[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -733,9 +733,9 @@ trait Or[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Xor[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def ^(
+trait Xor[D <: Data, RET <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def ^[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -746,9 +746,9 @@ trait Xor[D <: Data, RET <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
-trait Cat[D <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
-  extension (ref: LHS)
-    def ##(
+trait Cat[D <: Data]:
+  extension [LHS <: Referable[D]](ref: LHS)
+    def ##[RHS <: Referable[D]](
       that: RHS
     )(
       using Arena,
@@ -760,10 +760,10 @@ trait Cat[D <: Data, LHS <: Referable[D], RHS <: Referable[D]]:
       InstanceContext
     ): Node[D]
 
-trait Shl[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Shl[D <: Data, OUT <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def <<(
-      that: THAT
+      that: Int | Referable[UInt]
     )(
       using Arena,
       Context,
@@ -773,10 +773,10 @@ trait Shl[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
-trait Shr[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Shr[D <: Data, OUT <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def >>(
-      that: THAT
+      that: Int | Referable[UInt]
     )(
       using Arena,
       Context,
@@ -786,10 +786,10 @@ trait Shr[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[D]
-trait Head[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Head[D <: Data, OUT <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def head(
-      that: THAT
+      that: Int
     )(
       using Arena,
       Context,
@@ -799,10 +799,10 @@ trait Head[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
-trait Tail[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Tail[D <: Data, OUT <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def tail(
-      that: THAT
+      that: Int
     )(
       using Arena,
       Context,
@@ -812,10 +812,10 @@ trait Tail[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
-trait Pad[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
-  extension (ref: R)
+trait Pad[D <: Data, OUT <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def pad(
-      that: THAT
+      that: Int
     )(
       using Arena,
       Context,
@@ -825,11 +825,11 @@ trait Pad[D <: Data, THAT, OUT <: Data, R <: Referable[D]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
-trait ExtractRange[D <: Data, E <: Data, R <: Referable[D], IDX]:
-  extension (ref: R)
+trait ExtractRange[D <: Data, E <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def bits(
-      hi: IDX,
-      lo: IDX
+      hi: Int,
+      lo: Int
     )(
       using Arena,
       Context,
@@ -839,10 +839,10 @@ trait ExtractRange[D <: Data, E <: Data, R <: Referable[D], IDX]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[E]
-trait ExtractElement[D <: Data, E <: Data, R <: Referable[D], IDX]:
-  extension (ref: R)
+trait ExtractElement[D <: Data, E <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def bit(
-      idx: IDX
+      idx: Int
     )(
       using Arena,
       Context,
@@ -852,8 +852,8 @@ trait ExtractElement[D <: Data, E <: Data, R <: Referable[D], IDX]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[E]
-trait Mux[Cond <: Data, CondR <: Referable[Cond]]:
-  extension (ref: CondR)
+trait Mux[Cond <: Data]:
+  extension [CondR <: Referable[Cond]](ref: CondR)
     def ?[Ret <: Data](
       con: Referable[Ret],
       alt: Referable[Ret]
@@ -866,10 +866,10 @@ trait Mux[Cond <: Data, CondR <: Referable[Cond]]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[Ret]
-trait RefElement[D <: Data, E <: Data, R <: Referable[D], IDX]:
-  extension (ref: R)
+trait RefElement[D <: Data, E <: Data]:
+  extension [R <: Referable[D]](ref: R)
     def ref(
-      idx: IDX
+      idx: Int | Referable[UInt]
     )(
       using Arena,
       Context,
@@ -879,89 +879,86 @@ trait RefElement[D <: Data, E <: Data, R <: Referable[D], IDX]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Ref[E]
-trait GetLength[E <: Data, V <: Vec[E], R <: Referable[V]]:
-  extension (ref: R)
+trait GetLength[E <: Data, V <: Vec[E]]:
+  extension [R <: Referable[V]](ref: R)
     def length(
       using Arena,
       Context
     ): Int
 
-trait BitsApi[LHS <: Referable[Bits], RHS <: Referable[Bits]]
-    extends AsSInt[Bits, LHS]
-    with AsUInt[Bits, LHS]
-    with AsBool[Bits, LHS]
-    with AsBundle[Bits, LHS]
-    with AsRecord[Bits, LHS]
-    with AsVec[Bits, LHS]
-    with Not[Bits, Bits, LHS]
-    with AndR[Bits, Bool, LHS]
-    with OrR[Bits, Bool, LHS]
-    with XorR[Bits, Bool, LHS]
-    with Eq[Bits, Bool, LHS, RHS]
-    with Neq[Bits, Bool, LHS, RHS]
-    with And[Bits, Bits, LHS, RHS]
-    with Or[Bits, Bits, LHS, RHS]
-    with Xor[Bits, Bits, LHS, RHS]
-    with Cat[Bits, LHS, RHS]
-    with Shl[Bits, Int | Referable[UInt], Bits, LHS]
-    with Shr[Bits, Int | Referable[UInt], Bits, LHS]
-    with Head[Bits, Int, Bits, LHS]
-    with Tail[Bits, Int, Bits, LHS]
-    with Pad[Bits, Int, Bits, LHS]
-    with ExtractElement[Bits, Bool, LHS, Int]
-    with ExtractRange[Bits, Bits, LHS, Int]
+trait BitsApi
+    extends AsSInt[Bits]
+    with AsUInt[Bits]
+    with AsBool[Bits]
+    with AsBundle[Bits]
+    with AsRecord[Bits]
+    with AsVec[Bits]
+    with Not[Bits, Bits]
+    with AndR[Bits, Bool]
+    with OrR[Bits, Bool]
+    with XorR[Bits, Bool]
+    with Eq[Bits, Bool]
+    with Neq[Bits, Bool]
+    with And[Bits, Bits]
+    with Or[Bits, Bits]
+    with Xor[Bits, Bits]
+    with Cat[Bits]
+    with Shl[Bits, Bits]
+    with Shr[Bits, Bits]
+    with Head[Bits, Bits]
+    with Tail[Bits, Bits]
+    with Pad[Bits, Bits]
+    with ExtractElement[Bits, Bool]
+    with ExtractRange[Bits, Bits]
 
-trait BoolApi[LHS <: Referable[Bool], RHS <: Referable[Bool]]
-    extends AsBits[Bool, LHS]
-    with Neg[Bool, Bool, LHS]
-    with Eq[Bool, Bool, LHS, RHS]
-    with Neq[Bool, Bool, LHS, RHS]
-    with And[Bool, Bool, LHS, RHS]
-    with Or[Bool, Bool, LHS, RHS]
-    with Xor[Bool, Bool, LHS, RHS]
-    with Mux[Bool, LHS]
-trait UIntApi[LHS <: Referable[UInt], RHS <: Referable[UInt]]
-    extends AsBits[UInt, LHS]
-    with Add[UInt, UInt, LHS, RHS]
-    with Sub[UInt, UInt, LHS, RHS]
-    with Mul[UInt, UInt, LHS, RHS]
-    with Div[UInt, UInt, LHS, RHS]
-    with Rem[UInt, UInt, LHS, RHS]
-    with Lt[UInt, Bool, LHS, RHS]
-    with Leq[UInt, Bool, LHS, RHS]
-    with Gt[UInt, Bool, LHS, RHS]
-    with Geq[UInt, Bool, LHS, RHS]
-    with Eq[UInt, Bool, LHS, RHS]
-    with Neq[UInt, Bool, LHS, RHS]
-    with Shl[UInt, Int | Referable[UInt], UInt, LHS]
-    with Shr[UInt, Int | Referable[UInt], UInt, LHS]
-trait SIntApi[LHS <: Referable[SInt], RHS <: Referable[SInt]]
-    extends AsBits[SInt, LHS]
-    with Add[SInt, SInt, LHS, RHS]
-    with Sub[SInt, SInt, LHS, RHS]
-    with Mul[SInt, SInt, LHS, RHS]
-    with Div[SInt, SInt, LHS, RHS]
-    with Rem[SInt, SInt, LHS, RHS]
-    with Lt[SInt, Bool, LHS, RHS]
-    with Leq[SInt, Bool, LHS, RHS]
-    with Gt[SInt, Bool, LHS, RHS]
-    with Geq[SInt, Bool, LHS, RHS]
-    with Neq[SInt, Bool, LHS, RHS]
-    with Shl[SInt, Int | Referable[UInt], SInt, LHS]
-    with Shr[SInt, Int | Referable[UInt], SInt, LHS]
+trait BoolApi
+    extends AsBits[Bool]
+    with Neg[Bool, Bool]
+    with Eq[Bool, Bool]
+    with Neq[Bool, Bool]
+    with And[Bool, Bool]
+    with Or[Bool, Bool]
+    with Xor[Bool, Bool]
+    with Mux[Bool]
+trait UIntApi
+    extends AsBits[UInt]
+    with Add[UInt, UInt]
+    with Sub[UInt, UInt]
+    with Mul[UInt, UInt]
+    with Div[UInt, UInt]
+    with Rem[UInt, UInt]
+    with Lt[UInt, Bool]
+    with Leq[UInt, Bool]
+    with Gt[UInt, Bool]
+    with Geq[UInt, Bool]
+    with Eq[UInt, Bool]
+    with Neq[UInt, Bool]
+    with Shl[UInt, UInt]
+    with Shr[UInt, UInt]
+trait SIntApi
+    extends AsBits[SInt]
+    with Add[SInt, SInt]
+    with Sub[SInt, SInt]
+    with Mul[SInt, SInt]
+    with Div[SInt, SInt]
+    with Rem[SInt, SInt]
+    with Lt[SInt, Bool]
+    with Leq[SInt, Bool]
+    with Gt[SInt, Bool]
+    with Geq[SInt, Bool]
+    with Neq[SInt, Bool]
+    with Shl[SInt, SInt]
+    with Shr[SInt, SInt]
 
-trait BundleApi[T <: Bundle | ProbeBundle, R <: Referable[T]] extends AsBits[T, R]
+trait BundleApi[T <: Bundle | ProbeBundle] extends AsBits[T]
 
-trait RecordApi[T <: Record | ProbeRecord, R <: Referable[T]] extends AsBits[T, R]
+trait RecordApi[T <: Record | ProbeRecord] extends AsBits[T]
 
-trait VecApi[E <: Data, V <: Vec[E], R <: Referable[V]]
-    extends AsBits[V, R]
-    with RefElement[V, E, R, Referable[UInt] | Int]
-    with GetLength[E, V, R]
+trait VecApi[E <: Data, V <: Vec[E]] extends AsBits[V] with RefElement[V, E] with GetLength[E, V]
 
-trait ClockApi[R <: Referable[Clock]]
+trait ClockApi
 
-trait ResetApi[R <: Referable[Reset]] extends AsBool[Reset, R]
+trait ResetApi extends AsBool[Reset]
 
 trait TypeImpl:
   extension (ref: Interface[?])

--- a/zaozi/src/default/BitsApi.scala
+++ b/zaozi/src/default/BitsApi.scala
@@ -39,8 +39,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
-  extension (ref: LHS)
+given BitsApi with
+  extension [LHS <: Referable[Bits]](ref: LHS)
     def asSInt(
       using Arena,
       Context,
@@ -254,7 +254,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def ===(
+    def ===[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,
@@ -277,7 +277,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
       new Node[Bool]:
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
-    def =/=(
+    def =/=[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,
@@ -300,7 +300,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
       new Node[Bool]:
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
-    def &(
+    def &[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,
@@ -324,7 +324,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
         val _tpe:       Bits      = new Bits:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def |(
+    def |[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,
@@ -349,7 +349,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def ^(
+    def ^[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,
@@ -374,7 +374,7 @@ given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def ##(
+    def ##[RHS <: Referable[Bits]](
       that: RHS
     )(
       using Arena,

--- a/zaozi/src/default/BitsApi.scala
+++ b/zaozi/src/default/BitsApi.scala
@@ -39,8 +39,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [R <: Referable[Bits]]: BitsApi[R] with
-  extension (ref: R)
+given [LHS <: Referable[Bits], RHS <: Referable[Bits]]: BitsApi[LHS, RHS] with
+  extension (ref: LHS)
     def asSInt(
       using Arena,
       Context,
@@ -49,7 +49,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, SInt] =
+    ): Propagated[LHS, SInt] =
       val op0    = summon[AsSIntPrimApi].op(ref.refer, locate)
       op0.operation.appendToBlock()
       val nodeOp = summon[NodeApi].op(
@@ -61,7 +61,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       nodeOp.operation.appendToBlock()
       val tpe    = new SInt:
         private[zaozi] val _width = op0.result.getType.getBitWidth(true).toInt
-      propagate[R, SInt](ref, tpe, nodeOp.operation)
+      propagate[LHS, SInt](ref, tpe, nodeOp.operation)
     def asUInt(
       using Arena,
       Context,
@@ -70,7 +70,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, UInt] =
+    ): Propagated[LHS, UInt] =
       val nodeOp = summon[NodeApi].op(
         name = valName,
         location = locate,
@@ -80,7 +80,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       nodeOp.operation.appendToBlock()
       val tpe    = new UInt:
         private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
-      propagate[R, UInt](ref, tpe, nodeOp.operation)
+      propagate[LHS, UInt](ref, tpe, nodeOp.operation)
     def asBool(
       using Arena,
       Context,
@@ -89,7 +89,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, Bool] =
+    ): Propagated[LHS, Bool] =
       val nodeOp = summon[NodeApi].op(
         name = valName,
         location = locate,
@@ -102,7 +102,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         s"Cannot convert ${summon[sourcecode.Name.Machine]}: Bits(${width}) to Bool"
       )
       nodeOp.operation.appendToBlock()
-      propagate[R, Bool](ref, new Object with Bool, nodeOp.operation)
+      propagate[LHS, Bool](ref, new Object with Bool, nodeOp.operation)
     def asBundle[T <: Bundle](
       tpe: T
     )(
@@ -113,14 +113,14 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, T] =
+    ): Propagated[LHS, T] =
       val bitcastOp = summon[BitCastApi].op(
         input = ref.refer,
         tpe = tpe.toMlirType,
         location = locate
       )
       bitcastOp.operation.appendToBlock()
-      propagate[R, T](ref, tpe, bitcastOp.operation)
+      propagate[LHS, T](ref, tpe, bitcastOp.operation)
     def asRecord[T <: Record](
       tpe: T
     )(
@@ -131,14 +131,14 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, T] =
+    ): Propagated[LHS, T] =
       val bitcastOp = summon[BitCastApi].op(
         input = ref.refer,
         tpe = tpe.toMlirType,
         location = locate
       )
       bitcastOp.operation.appendToBlock()
-      propagate[R, T](ref, tpe, bitcastOp.operation)
+      propagate[LHS, T](ref, tpe, bitcastOp.operation)
     def asVec[E <: Data](
       tpe: E
     )(
@@ -149,7 +149,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, Vec[E]] =
+    ): Propagated[LHS, Vec[E]] =
       val srcWidth  = ref.refer.getType.getBitWidth(true).toInt
       val dstWidth  = tpe.toMlirType.getBitWidth(true).toInt
       require(
@@ -164,7 +164,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         location = locate
       )
       bitcastOp.operation.appendToBlock()
-      propagate[R, Vec[E]](ref, Vec[E](count, tpe), bitcastOp.operation)
+      propagate[LHS, Vec[E]](ref, Vec[E](count, tpe), bitcastOp.operation)
     def unary_~(
       using Arena,
       Context,
@@ -255,7 +255,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ===(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -278,7 +278,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
     def =/=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -301,7 +301,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
     def &(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -325,7 +325,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def |(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -350,7 +350,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ^(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -375,7 +375,7 @@ given [R <: Referable[Bits]]: BitsApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ##(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,

--- a/zaozi/src/default/BoolApi.scala
+++ b/zaozi/src/default/BoolApi.scala
@@ -22,8 +22,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
-  extension (ref: LHS)
+given BoolApi with
+  extension [LHS <: Referable[Bool]](ref: LHS)
     def unary_!(
       using Arena,
       Context,
@@ -66,7 +66,7 @@ given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
         private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
       propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
-    def ===(
+    def ===[RHS <: Referable[Bool]](
       that: RHS
     )(
       using Arena,
@@ -90,7 +90,7 @@ given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def =/=(
+    def =/=[RHS <: Referable[Bool]](
       that: RHS
     )(
       using Arena,
@@ -114,7 +114,7 @@ given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def &(
+    def &[RHS <: Referable[Bool]](
       that: RHS
     )(
       using Arena,
@@ -138,7 +138,7 @@ given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def |(
+    def |[RHS <: Referable[Bool]](
       that: RHS
     )(
       using Arena,
@@ -162,7 +162,7 @@ given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def ^(
+    def ^[RHS <: Referable[Bool]](
       that: RHS
     )(
       using Arena,

--- a/zaozi/src/default/BoolApi.scala
+++ b/zaozi/src/default/BoolApi.scala
@@ -22,8 +22,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [R <: Referable[Bool]]: BoolApi[R] with
-  extension (ref: R)
+given [LHS <: Referable[Bool], RHS <: Referable[Bool]]: BoolApi[LHS, RHS] with
+  extension (ref: LHS)
     def unary_!(
       using Arena,
       Context,
@@ -54,7 +54,7 @@ given [R <: Referable[Bool]]: BoolApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, Bits] =
+    ): Propagated[LHS, Bits] =
       val nodeOp = summon[NodeApi].op(
         name = valName,
         location = locate,
@@ -64,10 +64,10 @@ given [R <: Referable[Bool]]: BoolApi[R] with
       nodeOp.operation.appendToBlock()
       val tpe    = new Object with Bits:
         private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
-      propagate[R, Bits](ref, tpe, nodeOp.operation)
+      propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
     def ===(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -91,7 +91,7 @@ given [R <: Referable[Bool]]: BoolApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def =/=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -115,7 +115,7 @@ given [R <: Referable[Bool]]: BoolApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def &(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -139,7 +139,7 @@ given [R <: Referable[Bool]]: BoolApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def |(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -163,7 +163,7 @@ given [R <: Referable[Bool]]: BoolApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ^(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,

--- a/zaozi/src/default/BundleApi.scala
+++ b/zaozi/src/default/BundleApi.scala
@@ -14,8 +14,8 @@ import org.llvm.mlir.scalalib.capi.ir.{*, given}
 
 import java.lang.foreign.Arena
 
-given [T <: Bundle | ProbeBundle, R <: Referable[T]]: BundleApi[T, R] with
-  extension (ref: R)
+given [T <: Bundle | ProbeBundle]: BundleApi[T] with
+  extension [R <: Referable[T]](ref: R)
     def asBits(
       using Arena,
       Context,

--- a/zaozi/src/default/RecordApi.scala
+++ b/zaozi/src/default/RecordApi.scala
@@ -14,8 +14,8 @@ import org.llvm.mlir.scalalib.capi.ir.{*, given}
 
 import java.lang.foreign.Arena
 
-given [T <: Record | ProbeRecord, R <: Referable[T]]: RecordApi[T, R] with
-  extension (ref: R)
+given [T <: Record | ProbeRecord]: RecordApi[T] with
+  extension [R <: Referable[T]](ref: R)
     def asBits(
       using Arena,
       Context,

--- a/zaozi/src/default/ResetApi.scala
+++ b/zaozi/src/default/ResetApi.scala
@@ -13,8 +13,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 import java.lang.foreign.Arena
 import org.llvm.circt.scalalib.dialect.firrtl.operation.AsUIntPrimApi
 
-given [R <: Referable[Reset]]: ResetApi[R] with
-  extension (ref: R)
+given ResetApi with
+  extension [R <: Referable[Reset]](ref: R)
     def asBool(
       using Arena,
       Context,

--- a/zaozi/src/default/SIntApi.scala
+++ b/zaozi/src/default/SIntApi.scala
@@ -31,8 +31,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [R <: Referable[SInt]]: SIntApi[R] with
-  extension (ref: R)
+given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
+  extension (ref: LHS)
     def asBits(
       using Arena,
       Context,
@@ -41,7 +41,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, Bits] =
+    ): Propagated[LHS, Bits] =
       val op0    = summon[AsUIntPrimApi].op(ref.refer, locate)
       op0.operation.appendToBlock()
       val nodeOp = summon[NodeApi].op(
@@ -53,10 +53,10 @@ given [R <: Referable[SInt]]: SIntApi[R] with
       nodeOp.operation.appendToBlock()
       val tpe    = new Bits:
         private[zaozi] val _width = op0.result.getType.getBitWidth(true).toInt
-      propagate[R, Bits](ref, tpe, nodeOp.operation)
+      propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
     def +(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -81,7 +81,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def -(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -106,7 +106,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def *(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -131,7 +131,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def /(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -156,7 +156,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def %(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -181,7 +181,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def <(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -205,7 +205,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def <=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -229,7 +229,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def >(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -253,7 +253,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def >=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -277,7 +277,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ===(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -301,7 +301,7 @@ given [R <: Referable[SInt]]: SIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def =/=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,

--- a/zaozi/src/default/SIntApi.scala
+++ b/zaozi/src/default/SIntApi.scala
@@ -31,8 +31,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
-  extension (ref: LHS)
+given SIntApi with
+  extension [LHS <: Referable[SInt]](ref: LHS)
     def asBits(
       using Arena,
       Context,
@@ -55,7 +55,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         private[zaozi] val _width = op0.result.getType.getBitWidth(true).toInt
       propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
-    def +(
+    def +[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -80,7 +80,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def -(
+    def -[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -105,7 +105,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def *(
+    def *[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -130,7 +130,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def /(
+    def /[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -155,7 +155,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def %(
+    def %[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -180,7 +180,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
 
-    def <(
+    def <[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -204,7 +204,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def <=(
+    def <=[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -228,7 +228,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def >(
+    def >[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -252,7 +252,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def >=(
+    def >=[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -276,7 +276,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def ===(
+    def ===[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,
@@ -300,7 +300,7 @@ given [LHS <: Referable[SInt], RHS <: Referable[SInt]]: SIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def =/=(
+    def =/=[RHS <: Referable[SInt]](
       that: RHS
     )(
       using Arena,

--- a/zaozi/src/default/UIntApi.scala
+++ b/zaozi/src/default/UIntApi.scala
@@ -30,8 +30,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
-  extension (ref: LHS)
+given UIntApi with
+  extension [LHS <: Referable[UInt]](ref: LHS)
     def asBits(
       using Arena,
       Context,
@@ -52,7 +52,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
       propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
-    def +(
+    def +[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -76,7 +76,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       UInt      = new UInt:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def -(
+    def -[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -100,7 +100,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       UInt      = new UInt:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def *(
+    def *[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -124,7 +124,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       UInt      = new UInt:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def /(
+    def /[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -148,7 +148,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       UInt      = new UInt:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def %(
+    def %[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -172,7 +172,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       UInt      = new UInt:
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
-    def <(
+    def <[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -195,7 +195,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
       new Node[Bool]:
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
-    def <=(
+    def <=[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -219,7 +219,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def >(
+    def >[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -243,7 +243,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def >=(
+    def >=[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -267,7 +267,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def ===(
+    def ===[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,
@@ -291,7 +291,7 @@ given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
 
-    def =/=(
+    def =/=[RHS <: Referable[UInt]](
       that: RHS
     )(
       using Arena,

--- a/zaozi/src/default/UIntApi.scala
+++ b/zaozi/src/default/UIntApi.scala
@@ -30,8 +30,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [R <: Referable[UInt]]: UIntApi[R] with
-  extension (ref: R)
+given [LHS <: Referable[UInt], RHS <: Referable[UInt]]: UIntApi[LHS, RHS] with
+  extension (ref: LHS)
     def asBits(
       using Arena,
       Context,
@@ -40,7 +40,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
       sourcecode.Line,
       sourcecode.Name.Machine,
       InstanceContext
-    ): Propagated[R, Bits] =
+    ): Propagated[LHS, Bits] =
       val nodeOp = summon[NodeApi].op(
         name = valName,
         location = locate,
@@ -50,10 +50,10 @@ given [R <: Referable[UInt]]: UIntApi[R] with
       nodeOp.operation.appendToBlock()
       val tpe    = new Bits:
         private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
-      propagate[R, Bits](ref, tpe, nodeOp.operation)
+      propagate[LHS, Bits](ref, tpe, nodeOp.operation)
 
     def +(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -77,7 +77,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def -(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -101,7 +101,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def *(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -125,7 +125,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def /(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -149,7 +149,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def %(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -173,7 +173,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
           private[zaozi] val _width = nodeOp.operation.getResult(0).getType.getBitWidth(true).toInt
         val _operation: Operation = nodeOp.operation
     def <(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -196,7 +196,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
         val _tpe:       Bool      = new Object with Bool
         val _operation: Operation = nodeOp.operation
     def <=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -220,7 +220,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def >(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -244,7 +244,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def >=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -268,7 +268,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def ===(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,
@@ -292,7 +292,7 @@ given [R <: Referable[UInt]]: UIntApi[R] with
         val _operation: Operation = nodeOp.operation
 
     def =/=(
-      that: R
+      that: RHS
     )(
       using Arena,
       Context,

--- a/zaozi/src/default/VecApi.scala
+++ b/zaozi/src/default/VecApi.scala
@@ -12,8 +12,8 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
-given [E <: Data, V <: Vec[E], R <: Referable[V]]: VecApi[E, V, R] with
-  extension (ref: R)
+given [E <: Data, V <: Vec[E]]: VecApi[E, V] with
+  extension [R <: Referable[V]](ref: R)
     def asBits(
       using Arena,
       Context,

--- a/zaozi/src/magic/macros/Dynamic.scala
+++ b/zaozi/src/magic/macros/Dynamic.scala
@@ -165,6 +165,17 @@ private def getTypeParameters(
 
   (rType, vTypeOpt, eTypeOpt)
 
+private def summonTypeclassTerm(
+  using q:  Quotes
+)(typeRepr: q.reflect.TypeRepr
+): q.reflect.Term =
+  import q.reflect.*
+
+  Implicits.search(typeRepr) match
+    case success: ImplicitSearchSuccess => success.tree
+    case failure: ImplicitSearchFailure =>
+      report.errorAndAbort(s"Cannot summon ${typeRepr.show}: ${failure.explanation}")
+
 def referableApplyCall[T <: me.jiuyang.zaozi.valuetpe.Data: Type](
   using Quotes
 )(ref:       Expr[me.jiuyang.zaozi.reftpe.Referable[T]],
@@ -184,38 +195,30 @@ def referableApplyCall[T <: me.jiuyang.zaozi.valuetpe.Data: Type](
   // If we have more than one apply() method, we can dispatch them here based on the args type.
   val applyCallTerm = getTypeParameters(fieldValueExpr) match
     case (rType, Some(vType), Some(eType)) =>
+      val vecApiTerm = summonTypeclassTerm(TypeRepr.of[me.jiuyang.zaozi.VecApi].appliedTo(List(eType, vType)))
       args match
         case idx +: Nil =>
           Select
-            .unique(
-              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_VecApi_E_V_R"))
-                .appliedToTypes(List(eType, vType, rType)),
-              "ref"
-            )
+            .unique(vecApiTerm, "ref")
+            .appliedToTypes(List(rType))
             .appliedTo(fieldValueTerm)
             .appliedTo(idx)
             .appliedToArgs(contextualArgs)
         case _          => report.errorAndAbort(s"Expected 1 args, but got ${args.length}")
     case (rType, None, None)               =>
+      val bitsApiTerm = summonTypeclassTerm(TypeRepr.of[me.jiuyang.zaozi.BitsApi])
       args match
         case idx +: Nil      =>
           Select
-            .unique(
-              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_LHS_RHS"))
-                .appliedToTypes(List(rType, rType)),
-              // apply() is just the syntax sugar of bit/bits...
-              "bit"
-            )
+            .unique(bitsApiTerm, "bit")
+            .appliedToTypes(List(rType))
             .appliedTo(fieldValueTerm)
             .appliedTo(idx)
             .appliedToArgs(contextualArgs)
         case hi +: lo +: Nil =>
           Select
-            .unique(
-              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_LHS_RHS"))
-                .appliedToTypes(List(rType, rType)),
-              "bits"
-            )
+            .unique(bitsApiTerm, "bits")
+            .appliedToTypes(List(rType))
             .appliedTo(fieldValueTerm)
             .appliedToArgs(List(hi, lo))
             .appliedToArgs(contextualArgs)

--- a/zaozi/src/magic/macros/Dynamic.scala
+++ b/zaozi/src/magic/macros/Dynamic.scala
@@ -201,7 +201,8 @@ def referableApplyCall[T <: me.jiuyang.zaozi.valuetpe.Data: Type](
         case idx +: Nil      =>
           Select
             .unique(
-              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_R")).appliedToType(rType),
+              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_LHS_RHS"))
+                .appliedToTypes(List(rType, rType)),
               // apply() is just the syntax sugar of bit/bits...
               "bit"
             )
@@ -211,7 +212,8 @@ def referableApplyCall[T <: me.jiuyang.zaozi.valuetpe.Data: Type](
         case hi +: lo +: Nil =>
           Select
             .unique(
-              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_R")).appliedToType(rType),
+              Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_BitsApi_LHS_RHS"))
+                .appliedToTypes(List(rType, rType)),
               "bits"
             )
             .appliedTo(fieldValueTerm)

--- a/zaozi/tests/src/BitsSpec.scala
+++ b/zaozi/tests/src/BitsSpec.scala
@@ -246,7 +246,7 @@ object BitsSpec extends TestSuite:
           ref:  R,
           node: Node[Bool]
         )(
-          using And[Bool, Bool, R, Referable[Bool]],
+          using And[Bool, Bool],
           Arena,
           Context,
           Block,
@@ -277,7 +277,7 @@ object BitsSpec extends TestSuite:
           ref:  R,
           node: Node[Bits]
         )(
-          using Cat[Bits, R, Referable[Bits]],
+          using Cat[Bits],
           Arena,
           Context,
           Block,

--- a/zaozi/tests/src/BitsSpec.scala
+++ b/zaozi/tests/src/BitsSpec.scala
@@ -7,7 +7,7 @@ import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 import me.jiuyang.testlib.*
-import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Context, ContextApi}
+import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Block, Context, ContextApi}
 
 import java.lang.foreign.Arena
 import utest.*
@@ -234,6 +234,68 @@ object BitsSpec extends TestSuite:
           io.widenBits.dontCare()
           io.widenBits := io.a ## io.b
       Cat.verilogTest(BitsSpecParameter(8))(
+        "assign widenBits = {a, b};"
+      )
+
+    test("Mixed Ref and Node Bool operators"):
+      @generator
+      object MixedRefAndNodeBool
+          extends Generator[BitsSpecParameter, BitsSpecLayers, BitsSpecIO, BitsSpecProbe]
+          with HasVerilogTest:
+        def andGeneric[R <: Referable[Bool]](
+          ref:  R,
+          node: Node[Bool]
+        )(
+          using And[Bool, Bool, R, Referable[Bool]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[Bool] =
+          ref & node
+
+        def architecture(parameter: BitsSpecParameter) =
+          val io = summon[Interface[BitsSpecIO]]
+          io.sint.dontCare()
+          io.uint.dontCare()
+          io.bool := andGeneric(io.d, Node(io.d))
+          io.bits.dontCare()
+          io.widenBits.dontCare()
+      MixedRefAndNodeBool.verilogTest(BitsSpecParameter(8))(
+        "assign bool = d;"
+      )
+
+    test("Mixed Referable Bits operators"):
+      @generator
+      object MixedReferableBits
+          extends Generator[BitsSpecParameter, BitsSpecLayers, BitsSpecIO, BitsSpecProbe]
+          with HasVerilogTest:
+        def catGeneric[R <: Referable[Bits]](
+          ref:  R,
+          node: Node[Bits]
+        )(
+          using Cat[Bits, R, Referable[Bits]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[Bits] =
+          ref ## node
+
+        def architecture(parameter: BitsSpecParameter) =
+          val io = summon[Interface[BitsSpecIO]]
+          io.sint.dontCare()
+          io.uint.dontCare()
+          io.bool.dontCare()
+          io.bits.dontCare()
+          io.widenBits := catGeneric(io.a, Node(io.b))
+      MixedReferableBits.verilogTest(BitsSpecParameter(8))(
         "assign widenBits = {a, b};"
       )
 

--- a/zaozi/tests/src/SIntSpec.scala
+++ b/zaozi/tests/src/SIntSpec.scala
@@ -7,7 +7,7 @@ import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 import me.jiuyang.testlib.*
-import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Context, ContextApi}
+import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Block, Context, ContextApi}
 import org.llvm.mlir.scalalib.capi.pass.{given_PassManagerApi, PassManager, PassManagerApi}
 import utest.*
 
@@ -56,6 +56,51 @@ object SIntSpec extends TestSuite:
           io.bits.dontCare()
       Plus.verilogTest(SIntSpecParameter(8))(
         "assign sint = {a[7], a} + {b[7], b};"
+      )
+
+    test("Mixed Referable SInt operators"):
+      @generator
+      object MixedReferableSInt
+          extends Generator[SIntSpecParameter, SIntSpecLayers, SIntSpecIO, SIntSpecProbe]
+          with HasVerilogTest:
+        def subGeneric[R <: Referable[SInt]](
+          ref:  R,
+          node: Node[SInt]
+        )(
+          using Sub[SInt, SInt, R, Referable[SInt]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[SInt] =
+          ref - node
+
+        def geqGeneric[R <: Referable[SInt]](
+          ref:   R,
+          const: Const[SInt]
+        )(
+          using Geq[SInt, Bool, R, Referable[SInt]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[Bool] =
+          ref >= const
+
+        def architecture(parameter: SIntSpecParameter) =
+          val io = summon[Interface[SIntSpecIO]]
+          io.sint := subGeneric(io.a, Node(io.b))
+          io.bool := geqGeneric(Node(io.a), 0.S(parameter.width))
+          io.bits.dontCare()
+      MixedReferableSInt.verilogTest(SIntSpecParameter(8))(
+        "assign sint = {a[7], a} - {b[7], b};",
+        "assign bool = $signed(a) > -8'sh1;"
       )
 
     test("-"):

--- a/zaozi/tests/src/SIntSpec.scala
+++ b/zaozi/tests/src/SIntSpec.scala
@@ -67,7 +67,7 @@ object SIntSpec extends TestSuite:
           ref:  R,
           node: Node[SInt]
         )(
-          using Sub[SInt, SInt, R, Referable[SInt]],
+          using Sub[SInt, SInt],
           Arena,
           Context,
           Block,
@@ -82,7 +82,7 @@ object SIntSpec extends TestSuite:
           ref:   R,
           const: Const[SInt]
         )(
-          using Geq[SInt, Bool, R, Referable[SInt]],
+          using Geq[SInt, Bool],
           Arena,
           Context,
           Block,

--- a/zaozi/tests/src/UIntSpec.scala
+++ b/zaozi/tests/src/UIntSpec.scala
@@ -7,7 +7,7 @@ import me.jiuyang.zaozi.*
 import me.jiuyang.zaozi.reftpe.*
 import me.jiuyang.zaozi.valuetpe.*
 import me.jiuyang.testlib.*
-import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Context, ContextApi}
+import org.llvm.mlir.scalalib.capi.ir.{given_ContextApi, Block, Context, ContextApi}
 import org.llvm.mlir.scalalib.capi.pass.{given_PassManagerApi, PassManager, PassManagerApi}
 import utest.*
 
@@ -56,6 +56,51 @@ object UIntSpec extends TestSuite:
           io.bits.dontCare()
       Plus.verilogTest(UIntSpecParameter(8))(
         "assign uint = {1'h0, a} + {1'h0, b};"
+      )
+
+    test("Mixed Referable UInt operators"):
+      @generator
+      object MixedReferableUInt
+          extends Generator[UIntSpecParameter, UIntSpecLayers, UIntSpecIO, UIntSpecProbe]
+          with HasVerilogTest:
+        def addGeneric[R <: Referable[UInt]](
+          ref:  R,
+          node: Node[UInt]
+        )(
+          using Add[UInt, UInt, R, Referable[UInt]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[UInt] =
+          ref + node
+
+        def eqGeneric[R <: Referable[UInt]](
+          ref:   R,
+          const: Const[UInt]
+        )(
+          using Eq[UInt, Bool, R, Referable[UInt]],
+          Arena,
+          Context,
+          Block,
+          sourcecode.File,
+          sourcecode.Line,
+          sourcecode.Name.Machine,
+          InstanceContext
+        ): Node[Bool] =
+          ref === const
+
+        def architecture(parameter: UIntSpecParameter) =
+          val io = summon[Interface[UIntSpecIO]]
+          io.uint := addGeneric(io.a, Node(io.b))
+          io.bool := eqGeneric(Node(io.a), 0.U(parameter.width))
+          io.bits.dontCare()
+      MixedReferableUInt.verilogTest(UIntSpecParameter(8))(
+        "assign uint = {1'h0, a} + {1'h0, b};",
+        "assign bool = a == 8'h0;"
       )
 
     test("-"):

--- a/zaozi/tests/src/UIntSpec.scala
+++ b/zaozi/tests/src/UIntSpec.scala
@@ -67,7 +67,7 @@ object UIntSpec extends TestSuite:
           ref:  R,
           node: Node[UInt]
         )(
-          using Add[UInt, UInt, R, Referable[UInt]],
+          using Add[UInt, UInt],
           Arena,
           Context,
           Block,
@@ -82,7 +82,7 @@ object UIntSpec extends TestSuite:
           ref:   R,
           const: Const[UInt]
         )(
-          using Eq[UInt, Bool, R, Referable[UInt]],
+          using Eq[UInt, Bool],
           Arena,
           Context,
           Block,


### PR DESCRIPTION
The old API encoded operand shapes into domain-level bundles such as UIntApi and BitsApi, which made generic capability requirements depend on call-site forms.
Move operand roles to concrete operator methods instead, so domain APIs only describe available capabilities while generic Referable combinations still typecheck naturally.