### PR TITLE
refactor(zaozi): summon GeneratorApi in generator macro

### DIFF
--- a/zaozi/src/magic/macros/Generator.scala
+++ b/zaozi/src/magic/macros/Generator.scala
@@ -201,7 +201,14 @@ class generator extends MacroAnnotation:
               case '[tParam] =>
                 Some(
                   Select
-                    .unique(Ref(Symbol.requiredModule("me.jiuyang.zaozi.default.given_GeneratorApi")), "mainImpl")
+                    .unique(
+                      Expr
+                        .summon[me.jiuyang.zaozi.GeneratorApi]
+                        .getOrElse:
+                          report.errorAndAbort("No given instance of me.jiuyang.zaozi.GeneratorApi was found")
+                        .asTerm,
+                      "mainImpl"
+                    )
                     .appliedToTypeTrees(List(tptParam, tptL, tptI, tptP))
                     .appliedTo(This(objSym))
                     .appliedTo(argss.head.head.asExpr.asTerm)


### PR DESCRIPTION
This removes the macro's dependency on me.jiuyang.zaozi.default by resolving GeneratorApi through normal given search instead of a hardcoded default implementation module.