### PR TITLE
feat(zaozi): unify static and dynamic right shift result width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 .opencode/
 .scala-build/
 __pycache__/
+.codex
+.humanize/
 
 out/
 result*

--- a/zaozi/src/default/BitsApi.scala
+++ b/zaozi/src/default/BitsApi.scala
@@ -445,9 +445,13 @@ given BitsApi with
         nameKind = FirrtlNameKind.Interesting,
         input = that match
           case that: Int             =>
-            val op0 = summon[ShrPrimApi].op(ref.refer, that, locate)
+            val input         = ref.refer
+            val originalWidth = input.getType.getBitWidth(true).toInt
+            val op0           = summon[ShrPrimApi].op(input, that, locate)
             op0.operation.appendToBlock()
-            op0.result
+            val op1           = summon[PadPrimApi].op(op0.result, originalWidth, locate)
+            op1.operation.appendToBlock()
+            op1.result
           case that: Referable[UInt] =>
             val op0 = summon[DShrPrimApi].op(ref.refer, that.refer, locate)
             op0.operation.appendToBlock()

--- a/zaozi/src/default/SIntApi.scala
+++ b/zaozi/src/default/SIntApi.scala
@@ -21,6 +21,7 @@ import org.llvm.circt.scalalib.dialect.firrtl.operation.{
   MulPrimApi,
   NEQPrimApi,
   NodeApi,
+  PadPrimApi,
   RemPrimApi,
   ShlPrimApi,
   ShrPrimApi,
@@ -372,9 +373,13 @@ given SIntApi with
         nameKind = FirrtlNameKind.Interesting,
         input = that match
           case that: Int             =>
-            val op0 = summon[ShrPrimApi].op(ref.refer, that, locate)
+            val input         = ref.refer
+            val originalWidth = input.getType.getBitWidth(true).toInt
+            val op0           = summon[ShrPrimApi].op(input, that, locate)
             op0.operation.appendToBlock()
-            op0.result
+            val op1           = summon[PadPrimApi].op(op0.result, originalWidth, locate)
+            op1.operation.appendToBlock()
+            op1.result
           case that: Referable[UInt] =>
             val op0 = summon[DShrPrimApi].op(ref.refer, that.refer, locate)
             op0.operation.appendToBlock()

--- a/zaozi/src/default/UIntApi.scala
+++ b/zaozi/src/default/UIntApi.scala
@@ -20,6 +20,7 @@ import org.llvm.circt.scalalib.dialect.firrtl.operation.{
   MulPrimApi,
   NEQPrimApi,
   NodeApi,
+  PadPrimApi,
   RemPrimApi,
   ShlPrimApi,
   ShrPrimApi,
@@ -362,9 +363,13 @@ given UIntApi with
         nameKind = FirrtlNameKind.Interesting,
         input = that match
           case that: Int             =>
-            val op0 = summon[ShrPrimApi].op(ref.refer, that, locate)
+            val input         = ref.refer
+            val originalWidth = input.getType.getBitWidth(true).toInt
+            val op0           = summon[ShrPrimApi].op(input, that, locate)
             op0.operation.appendToBlock()
-            op0.result
+            val op1           = summon[PadPrimApi].op(op0.result, originalWidth, locate)
+            op1.operation.appendToBlock()
+            op1.result
           case that: Referable[UInt] =>
             val op0 = summon[DShrPrimApi].op(ref.refer, that.refer, locate)
             op0.operation.appendToBlock()

--- a/zaozi/tests/src/BitsSpec.scala
+++ b/zaozi/tests/src/BitsSpec.scala
@@ -342,13 +342,15 @@ object BitsSpec extends TestSuite:
           extends Generator[BitsSpecParameter, BitsSpecLayers, BitsSpecIO, BitsSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: BitsSpecParameter) =
-          val io = summon[Interface[BitsSpecIO]]
+          val io      = summon[Interface[BitsSpecIO]]
+          val shifted = io.a >> 4
+          assert(shifted.width == parameter.width)
           io.sint.dontCare()
           io.uint.dontCare()
           io.bool.dontCare()
           io.bits.dontCare()
           io.widenBits.dontCare()
-          io.bits := io.a >> 4
+          io.bits := shifted
       ShiftRightInt.verilogTest(BitsSpecParameter(8))(
         "assign bits = {4'h0, a[7:4]};"
       )
@@ -359,13 +361,15 @@ object BitsSpec extends TestSuite:
           extends Generator[BitsSpecParameter, BitsSpecLayers, BitsSpecIO, BitsSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: BitsSpecParameter) =
-          val io = summon[Interface[BitsSpecIO]]
+          val io      = summon[Interface[BitsSpecIO]]
+          val shifted = io.a >> io.c
+          assert(shifted.width == parameter.width)
           io.sint.dontCare()
           io.uint.dontCare()
           io.bool.dontCare()
           io.bits.dontCare()
           io.widenBits.dontCare()
-          io.bits := io.a >> io.c
+          io.bits := shifted
       ShiftRightUInt.verilogTest(BitsSpecParameter(8))(
         "assign bits = a >> c;"
       )

--- a/zaozi/tests/src/SIntSpec.scala
+++ b/zaozi/tests/src/SIntSpec.scala
@@ -120,7 +120,7 @@ object SIntSpec extends TestSuite:
       object Times extends Generator[SIntSpecParameter, SIntSpecLayers, SIntSpecIO, SIntSpecProbe] with HasVerilogTest:
         def architecture(parameter: SIntSpecParameter) =
           val io = summon[Interface[SIntSpecIO]]
-          io.sint := ((io.a * io.b).asBits >> parameter.width).asSInt
+          io.sint := (io.a * io.b).asBits.head(parameter.width).asSInt
           io.bool.dontCare()
           io.bits.dontCare()
       Times.verilogTest(SIntSpecParameter(8))(
@@ -268,8 +268,10 @@ object SIntSpec extends TestSuite:
           extends Generator[SIntSpecParameter, SIntSpecLayers, SIntSpecIO, SIntSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: SIntSpecParameter) =
-          val io = summon[Interface[SIntSpecIO]]
-          io.sint := io.a >> 4
+          val io      = summon[Interface[SIntSpecIO]]
+          val shifted = io.a >> 4
+          assert(shifted.width == parameter.width)
+          io.sint := shifted
           io.bool.dontCare()
           io.bits.dontCare()
       ShiftRightInt.verilogTest(SIntSpecParameter(8))(
@@ -282,11 +284,13 @@ object SIntSpec extends TestSuite:
           extends Generator[SIntSpecParameter, SIntSpecLayers, SIntSpecIO, SIntSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: SIntSpecParameter) =
-          val io = summon[Interface[SIntSpecIO]]
-          io.sint := io.a >> io.c
+          val io      = summon[Interface[SIntSpecIO]]
+          val shifted = io.a >> io.c
+          assert(shifted.width == parameter.width)
+          io.sint := shifted
           io.bool.dontCare()
           io.bits.dontCare()
       ShiftRightUInt.verilogTest(SIntSpecParameter(8))(
-        "wire [7:0] _GEN_0 = $unsigned($signed($signed(a) >>> c));",
-        "assign sint = {_GEN_0[7], _GEN_0};"
+        "wire [7:0] shifted = $unsigned($signed($signed(a) >>> c));",
+        "assign sint = {shifted[7], shifted};"
       )

--- a/zaozi/tests/src/UIntSpec.scala
+++ b/zaozi/tests/src/UIntSpec.scala
@@ -270,8 +270,10 @@ object UIntSpec extends TestSuite:
           extends Generator[UIntSpecParameter, UIntSpecLayers, UIntSpecIO, UIntSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: UIntSpecParameter) =
-          val io = summon[Interface[UIntSpecIO]]
-          io.uint := io.a >> 4
+          val io      = summon[Interface[UIntSpecIO]]
+          val shifted = io.a >> 4
+          assert(shifted.width == parameter.width)
+          io.uint := shifted
           io.bool.dontCare()
           io.bits.dontCare()
       RightShiftInt.verilogTest(UIntSpecParameter(8))(
@@ -284,8 +286,10 @@ object UIntSpec extends TestSuite:
           extends Generator[UIntSpecParameter, UIntSpecLayers, UIntSpecIO, UIntSpecProbe]
           with HasVerilogTest:
         def architecture(parameter: UIntSpecParameter) =
-          val io = summon[Interface[UIntSpecIO]]
-          io.uint := io.a >> io.b
+          val io      = summon[Interface[UIntSpecIO]]
+          val shifted = io.a >> io.b
+          assert(shifted.width == parameter.width)
+          io.uint := shifted
           io.bool.dontCare()
           io.bits.dontCare()
       RightShiftUInt.verilogTest(UIntSpecParameter(8))(


### PR DESCRIPTION
Append firrtl.pad after firrtl.shr in the static >> path so the result preserves the original input width, matching the dynamic shift (firrtl.dshr) behavior. Applies to UInt, SInt, and Bits.