### PR TITLE
add mill-version in build.mill to make lsp happy 

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -1,3 +1,4 @@
+//| mill-version: 1.1.2
 //| mill-jvm-version: system
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-jmh:$MILL_VERSION


### PR DESCRIPTION
This PR adds a `mill-version` in `build.mill` with the project’s expected Mill version, `1.1.2`.

Without an explicit Mill version, the Mill wrapper generated by Metals does not immediately use the `mill` executable available in the current environment. Instead, it first tries to determine the project Mill version from configuration files. If none is found, it falls back to resolving the latest Mill release and may attempt to download that version.

In a Nix/direnv development shell already provides Mill `1.1.2`, but Metals’ generated wrapper may resolve a newer latest version instead. When that happens, the wrapper creates a temporary download file using `mktemp mill.XXXXXX` in the project root. If the download fails or is interrupted, an empty `mill.XXXXXX` file can be left behind.

Adding `mill-version` makes the project’s Mill version explicit. Metals and Mill wrappers can now resolve the intended version directly, match it against the Nix-provided Mill binary, and avoid the unnecessary latest-version lookup/download path. This keeps BSP initialization deterministic and prevents stray `mill.XXXXXX` files from appearing in the repository root.