### PR TITLE
build: bump CIRCT

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,29 +2,26 @@
   "nodes": {
     "circt-nix": {
       "inputs": {
-        "circt-src": [
-          "circt-src"
-        ],
+        "circt-src": "circt-src",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "llvm-submodule-src": [
-          "llvm-src"
-        ],
+        "llvm-submodule-src": "llvm-submodule-src",
         "nixpkgs": [
           "nixpkgs"
         ],
         "slang-src": "slang-src"
       },
       "locked": {
-        "lastModified": 1779370424,
-        "narHash": "sha256-q0FpuqQ9lLH5tGE2DffPzqisx4y7iuHuwq79HbhByS4=",
-        "owner": "unlsycn",
+        "lastModified": 1782305456,
+        "narHash": "sha256-hbRFW5nx0lsTafDI9F43wUibrQ5t7+BKJamY1jKwej0=",
+        "owner": "xinpian-tech",
         "repo": "circt-nix",
-        "rev": "8e8c00adc52d19be0acc302b19c7e0a58065d90c",
+        "rev": "6430b6632608aa3acde9866e5658a48e43802d22",
         "type": "github"
       },
       "original": {
-        "owner": "unlsycn",
+        "owner": "xinpian-tech",
+        "ref": "xinpian-main",
         "repo": "circt-nix",
         "type": "github"
       }
@@ -32,16 +29,16 @@
     "circt-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779324920,
-        "narHash": "sha256-uuRtkPF75Vwem6aqbQpAMp9mgxTxGuUQ+lnnytAcC8I=",
-        "owner": "llvm",
+        "lastModified": 1782226806,
+        "narHash": "sha256-icHRstozpMiu9Jlk9q9ROlC/fueiGQLdAlRMP10Pvq0=",
+        "owner": "xinpian-tech",
         "repo": "circt",
-        "rev": "5306f6fde0007cd4ca53f1981ebab98a2f83fd36",
+        "rev": "b14826f973799604756a5c745c938a7749b082b2",
         "type": "github"
       },
       "original": {
-        "owner": "llvm",
-        "ref": "main",
+        "owner": "xinpian-tech",
+        "ref": "xinpian-main",
         "repo": "circt",
         "type": "github"
       }
@@ -119,20 +116,20 @@
         "type": "github"
       }
     },
-    "llvm-src": {
+    "llvm-submodule-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778901466,
-        "narHash": "sha256-3llZ6LQ7B1TrRn6g7DsWkl6Lr6IjfDPb1TEfhwwl8h4=",
+        "lastModified": 1780700903,
+        "narHash": "sha256-rms9EtZ/58qdrO45SsxFDGlYIBy1mnIpDZoD/5fyrQ4=",
         "owner": "llvm",
         "repo": "llvm-project",
-        "rev": "e6566c571aead7b48bdf13a8c170515abaeea74e",
+        "rev": "b7152ff7026a05282b6ae91ccf150ede0217b08a",
         "type": "github"
       },
       "original": {
         "owner": "llvm",
         "repo": "llvm-project",
-        "rev": "e6566c571aead7b48bdf13a8c170515abaeea74e",
+        "rev": "b7152ff7026a05282b6ae91ccf150ede0217b08a",
         "type": "github"
       }
     },
@@ -143,11 +140,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1772549846,
-        "narHash": "sha256-R6J8KOey8OyEE7cAV8G1U2gY0eOrPJkBAHR7pX3yryo=",
+        "lastModified": 1772960587,
+        "narHash": "sha256-JXcsEMWWoChpsCPuJQJaTdkEemC4Q5bcu3fPNTJvTGk=",
         "owner": "Avimitin",
         "repo": "mill-ivy-fetcher",
-        "rev": "325b485c8213b2f21677c0fae240b13f85055d7a",
+        "rev": "54fbe54b4ad66d0dcefc240ed6388238c5fc1dfd",
         "type": "github"
       },
       "original": {
@@ -174,11 +171,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1769987528,
-        "narHash": "sha256-sQ6JzVhMuNcIz95KFfpolqMNbMqbi8OnI1EUIagbWtk=",
+        "lastModified": 1782231800,
+        "narHash": "sha256-AyPvq+cx3JFicSd687dhhIfUMryk9PUFmHnofBjalMg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "faa7f0dbe6480ab660843ab5f44735965f6283e9",
+        "rev": "6f5e2d2ea55618c5197ce40e346f205c35d2213e",
         "type": "github"
       },
       "original": {
@@ -191,9 +188,7 @@
     "root": {
       "inputs": {
         "circt-nix": "circt-nix",
-        "circt-src": "circt-src",
         "flake-utils": "flake-utils_2",
-        "llvm-src": "llvm-src",
         "mill-ivy-fetcher": "mill-ivy-fetcher",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,29 +5,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
-    circt-src = {
-      type = "github";
-      owner = "llvm";
-      repo = "circt";
-      ref = "main";
-      flake = false;
-    };
-    llvm-src = {
-      type = "github";
-      owner = "llvm";
-      repo = "llvm-project";
-      # from CIRCT submodule
-      rev = "e6566c571aead7b48bdf13a8c170515abaeea74e";
-      flake = false;
-    };
-    circt-nix = {
-      url = "github:unlsycn/circt-nix";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-        circt-src.follows = "circt-src";
-        llvm-submodule-src.follows = "llvm-src";
-      };
-    };
+    circt-nix.url = "github:xinpian-tech/circt-nix/xinpian-main";
     flake-utils.url = "github:numtide/flake-utils";
     mill-ivy-fetcher.url = "github:Avimitin/mill-ivy-fetcher";
   };

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,13 +3,6 @@
 final: prev:
 
 {
-  mlir = prev.llvmPackages_circt.mlir.override { buildSharedLibs = true; };
-  libllvm = prev.llvmPackages_circt.libllvm.override { buildSharedLibs = true; };
-  circt = prev.circt.override {
-    buildSharedLibs = true;
-    inherit (final) libllvm mlir;
-  };
-
   circt-install = final.callPackage ./pkgs/circt-install.nix { };
 
   mlir-install = final.callPackage ./pkgs/mlir-install.nix { };


### PR DESCRIPTION
Bump circt with xinpian-tech's circt source but `nix build .#circt-install -L` fails.

## Root cause
The pinned nixpkgs (2026-02) was ~4 months older than the pinned LLVM `b7152ff` (2026-06). Building against a newer LLVM with older nixpkgs LLVM infrastructure broke in three places:

1. **Stale patch** — nixpkgs' `gnu-install-dirs.patch` no longer applied: `hunk #3` of `cmake/modules/AddLLVM.cmake` was shifted out of context by LLVM's newly inserted `LLVM_ENABLE_PER_TARGET_RUNTIME_DIR` block in `llvm_setup_rpath`.
2. **Missing `libc`** — LLVM 23 added an unconditional `llvm-libc-common-utilities` check (`llvm/CMakeLists.txt`), but the old `tblgen.nix` did not copy the `libc` subdirectory into the source, so configure aborted with "LLVM libc is not found".
3. **benchmark `-Werror`** — under the newer toolchain, LLVM's bundled `third-party/benchmark` fails to compile: LLVM's CMake adds `-D_LIBCPP_HARDENING_MODE=...` globally while the cc-wrapper injects the same macro with a different value, yielding a `'_LIBCPP_HARDENING_MODE' redefined` warning. benchmark (and only benchmark) builds with `-Werror`/`-pedantic-errors`, so the warning becomes a fatal error there.

## Fix
- **`flake.lock`**: bump nixpkgs to 2026-06-16 (contemporary with the LLVM rev). This resolves (1) and (2) directly — the current `gnu-install-dirs.patch` applies cleanly and `tblgen.nix` copies `libc`.
- **`nix/overlay.nix`**: disable LLVM benchmarks (not needed by `circt-install`) to resolve (3). This is done **inside the LLVM package scope** (`overrideScope`), and both `libllvm` and `mlir` are taken from that single scope. Otherwise `.override { buildSharedLibs = true; }` re-evaluates circt-nix's `llvm.nix` once per package; combined with a top-level `overrideAttrs`, that diverges into two separate LLVM builds, and the copy `mlir` builds for itself still compiles the benchmarks and hits the error. Building from one scope keeps it to a single LLVM. The exposed scope defaults to `BUILD_SHARED_LIBS=OFF`, so the shared-libs flag is re-added (the only thing `buildSharedLibs=true` had changed).