### PR TITLE
Add doc comments to the public API surface

### DIFF
--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -75,13 +75,13 @@ abstract class LayerInterface[P <: Parameter](parameter: P) extends Seq[LayerTre
 trait HWInterface[P <: Parameter](parameter: P) extends Aggregate:
   this: Bundle | Record =>
 
-/** A [[Generator]]'s IO declared as a [[Bundle]] -- fields are `val`s, as in [[me.jiuyang.hello.HelloWorldIO]] /
-  * `me.jiuyang.varadder.VarAdderIO`.
+/** A [[Generator]]'s IO declared as a [[me.jiuyang.zaozi.valuetpe.Bundle Bundle]] -- fields are `val`s, as in
+  * `me.jiuyang.hello.HelloWorldIO` / `me.jiuyang.varadder.VarAdderIO`.
   */
 abstract class HWBundle[P <: Parameter](parameter: P) extends HWInterface(parameter) with Bundle
 
-/** A [[Generator]]'s IO declared as a [[Record]] -- fields are named dynamically, for ports whose shape isn't known
-  * until `parameter` is inspected.
+/** A [[Generator]]'s IO declared as a [[me.jiuyang.zaozi.valuetpe.Record Record]] -- fields are named dynamically, for
+  * ports whose shape isn't known until `parameter` is inspected.
   */
 abstract class HWRecord[P <: Parameter](parameter: P) extends HWInterface(parameter) with Record
 
@@ -97,14 +97,17 @@ trait DVInterface[P <: Parameter, L <: LayerInterface[P]](parameter: P) extends 
   transparent inline def layers:       L                 = _layersOpt.getOrElse:
     summonLayers.asInstanceOf[L].tap(l => _layersOpt = Some(l))
 
-/** A [[Generator]]'s debug interface declared as a [[ProbeBundle]] -- probe fields are `val`s, as in
-  * `me.jiuyang.varadder.VarAdderProbe`. Modules with no probes still declare one, typically empty.
+/** A [[Generator]]'s debug interface declared as a [[me.jiuyang.zaozi.valuetpe.ProbeBundle ProbeBundle]] -- probe
+  * fields are `val`s, as in `me.jiuyang.varadder.VarAdderProbe`. Modules with no probes still declare one, typically
+  * empty.
   */
 abstract class DVBundle[P <: Parameter, L <: LayerInterface[P]](parameter: P)
     extends DVInterface[P, L](parameter)
     with ProbeBundle
 
-/** A [[Generator]]'s debug interface declared as a [[ProbeRecord]] -- probe fields are named dynamically. */
+/** A [[Generator]]'s debug interface declared as a [[me.jiuyang.zaozi.valuetpe.ProbeRecord ProbeRecord]] -- probe
+  * fields are named dynamically.
+  */
 abstract class DVRecord[P <: Parameter, L <: LayerInterface[P]](parameter: P)
     extends DVInterface[P, L](parameter)
     with ProbeRecord
@@ -282,8 +285,9 @@ trait GeneratorApi:
     ): Instance[I, P]
 
     /** Elaborates (once per distinct `parameter`, memoized) and instantiates `generator` as a sub-module of the
-      * enclosing architecture, e.g. `Subtractor.instantiate(SubtractorParameter(width))`. Returns an [[Instance]] whose
-      * `.io`/`.probe` are the sub-module's ports/probes, wired with `:=`/`<==` like any other `Referable`.
+      * enclosing architecture, e.g. `Subtractor.instantiate(SubtractorParameter(width))`. Returns an
+      * [[me.jiuyang.zaozi.reftpe.Instance Instance]] whose `.io`/`.probe` are the sub-module's ports/probes, wired with
+      * `:=`/`<==` like any other `Referable`.
       */
     def instantiate(
       parameter: PARAM
@@ -590,7 +594,8 @@ trait AsUInt[D <: Data]:
       InstanceContext
     ): Propagated[R, UInt]
 
-/** Bitcasts to a [[Bundle]] shape: reinterprets the same underlying bits as `tpe`'s fields, with no runtime cost.
+/** Bitcasts to a [[me.jiuyang.zaozi.valuetpe.Bundle Bundle]] shape: reinterprets the same underlying bits as `tpe`'s
+  * fields, with no runtime cost.
   */
 trait AsBundle[D <: Data]:
   extension [R <: Referable[D]](ref: R)
@@ -606,7 +611,9 @@ trait AsBundle[D <: Data]:
       InstanceContext
     ): Propagated[R, T]
 
-/** Bitcasts to a [[Record]] shape: reinterprets the same underlying bits as `tpe`'s named fields. */
+/** Bitcasts to a [[me.jiuyang.zaozi.valuetpe.Record Record]] shape: reinterprets the same underlying bits as `tpe`'s
+  * named fields.
+  */
 trait AsRecord[D <: Data]:
   extension [R <: Referable[D]](ref: R)
     def asRecord[T <: Record](
@@ -621,8 +628,8 @@ trait AsRecord[D <: Data]:
       InstanceContext
     ): Propagated[R, T]
 
-/** Bitcasts to a [[Vec]] of `tpe` elements: the source width must divide evenly by `tpe`'s width, producing
-  * `srcWidth / tpe.width` elements.
+/** Bitcasts to a [[me.jiuyang.zaozi.valuetpe.Vec Vec]] of `tpe` elements: the source width must divide evenly by
+  * `tpe`'s width, producing `srcWidth / tpe.width` elements.
   */
 trait AsVec[D <: Data]:
   extension [R <: Referable[D]](ref: R)
@@ -644,16 +651,19 @@ trait AsVec[D <: Data]:
 trait AsRecordView[D <: Bundle]:
   extension [R <: Referable[D] & HasOperation](ref: R) def asRecord: Propagated[R, Record]
 
-/** The [[ProbeBundle]]/[[ProbeRecord]] counterpart to [[AsRecordView]]. */
+/** The [[me.jiuyang.zaozi.valuetpe.ProbeBundle ProbeBundle]]/[[me.jiuyang.zaozi.valuetpe.ProbeRecord ProbeRecord]]
+  * counterpart to [[AsRecordView]].
+  */
 trait AsProbeRecordView[D <: ProbeBundle]:
   extension [R <: Referable[D] & HasOperation](ref: R) def asRecord: Propagated[R, ProbeRecord]
 
-/** Connects probe reference fields ([[RProbe]]/[[RWProbe]]), via `<==`, three ways: define a probe from the data it
-  * observes (`probeField <== dataValue`), alias one probe field to another (`probeField <== otherProbeField`), or, on
-  * the reading side, resolve a probe back into an ordinary value (`dataValue <== probeField`). Ordinary `:=`/`:<=`/etc.
+/** Connects probe reference fields ([[me.jiuyang.zaozi.valuetpe.RProbe RProbe]]/
+  * [[me.jiuyang.zaozi.valuetpe.RWProbe RWProbe]]), via `<==`, three ways: define a probe from the data it observes
+  * (`probeField <== dataValue`), alias one probe field to another (`probeField <== otherProbeField`), or, on the
+  * reading side, resolve a probe back into an ordinary value (`dataValue <== probeField`). Ordinary `:=`/`:<=`/etc.
   * deliberately reject probe types (see the "probe types do not participate in bulk connects" error in
-  * `me.jiuyang.zaozi.default.Connect`) -- `<==` is the only way to connect them, and it requires an enclosing [[layer]]
-  * for the color check.
+  * `me.jiuyang.zaozi.default.Connect`) -- `<==` is the only way to connect them, and it requires an enclosing
+  * [[ConstructorApi.layer]] for the color check.
   */
 trait ProbeConnect[D <: Data & CanProbe, P <: RWProbe[D] | RProbe[D], DATA <: Referable[D], PROBE <: Referable[P]]:
   extension (ref: PROBE)
@@ -720,9 +730,9 @@ final class ConnectException(message: String) extends Exception(message)
   */
 trait Connect[A <: Connectable]:
   extension [SINK <: Writable[A]](sink:  SINK)
-    /** Plain mono-directional connect, sink `<-` source. Only defined for scalar ([[Element]]) types -- no structural
-      * recursion, so it's the one operator usable inside `when`/`otherwise` branches where the sink's shape must
-      * already be known to be a leaf.
+    /** Plain mono-directional connect, sink `<-` source. Only defined for scalar
+      * ([[me.jiuyang.zaozi.valuetpe.Element]]) types -- no structural recursion, so it's the one operator usable inside
+      * `when`/`otherwise` branches where the sink's shape must already be known to be a leaf.
       */
     def :=[SRC <: Referable[A]](
       src: SRC
@@ -1177,8 +1187,9 @@ trait Mux[Cond <: Data]:
       InstanceContext
     ): Node[Ret]
 
-/** Indexes into a [[Vec]]-like `D`, either statically (`Int`, a fixed `SubindexOp`) or dynamically (`Referable[UInt]`,
-  * a `SubaccessOp` selected at runtime). `apply` is the usual spelling, e.g. `vec(3)` or `vec(io.sel)`.
+/** Indexes into a [[me.jiuyang.zaozi.valuetpe.Vec Vec]]-like `D`, either statically (`Int`, a fixed `SubindexOp`) or
+  * dynamically (`Referable[UInt]`, a `SubaccessOp` selected at runtime). `apply` is the usual spelling, e.g. `vec(3)`
+  * or `vec(io.sel)`.
   */
 trait RefElement[D <: Data, E <: Data]:
   extension [R <: Referable[D]](ref: R)
@@ -1200,8 +1211,9 @@ trait GetLength[E <: Data, V <: Vec[E]]:
       Context
     ): Int
 
-/** The full extension-method surface of [[Bits]]: casts, bitwise ops, structural ops (concat/slice/shift), but no
-  * arithmetic (`+`, `-`, ... -- cast to [[UInt]]/[[SInt]] first). Implemented by `me.jiuyang.zaozi.default.BitsApi`.
+/** The full extension-method surface of [[me.jiuyang.zaozi.valuetpe.Bits Bits]]: casts, bitwise ops, structural ops
+  * (concat/slice/shift), but no arithmetic (`+`, `-`, ... -- cast to [[me.jiuyang.zaozi.valuetpe.UInt UInt]]/
+  * [[me.jiuyang.zaozi.valuetpe.SInt SInt]] first). Implemented by `me.jiuyang.zaozi.default.BitsApi`.
   */
 trait BitsApi
     extends AsSInt[Bits]
@@ -1228,8 +1240,8 @@ trait BitsApi
     with ExtractElement[Bits, Bool]
     with ExtractRange[Bits, Bits]
 
-/** The extension-method surface of [[Bool]]: logical ops, equality, and the [[Mux]] `?` operator. Implemented by
-  * `me.jiuyang.zaozi.default.BoolApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Bool Bool]]: logical ops, equality, and the [[Mux]] `?`
+  * operator. Implemented by `me.jiuyang.zaozi.default.BoolApi`.
   */
 trait BoolApi
     extends AsBits[Bool]
@@ -1241,8 +1253,8 @@ trait BoolApi
     with Xor[Bool, Bool]
     with Mux[Bool]
 
-/** The extension-method surface of [[UInt]]: arithmetic, comparison, and static/dynamic shifts. Implemented by
-  * `me.jiuyang.zaozi.default.UIntApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.UInt UInt]]: arithmetic, comparison, and static/dynamic
+  * shifts. Implemented by `me.jiuyang.zaozi.default.UIntApi`.
   */
 trait UIntApi
     extends AsBits[UInt]
@@ -1260,8 +1272,8 @@ trait UIntApi
     with Shl[UInt, UInt]
     with Shr[UInt, UInt]
 
-/** The extension-method surface of [[SInt]]: signed arithmetic, comparison, and static/dynamic shifts. Implemented by
-  * `me.jiuyang.zaozi.default.SIntApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.SInt SInt]]: signed arithmetic, comparison, and
+  * static/dynamic shifts. Implemented by `me.jiuyang.zaozi.default.SIntApi`.
   */
 trait SIntApi
     extends AsBits[SInt]
@@ -1278,27 +1290,29 @@ trait SIntApi
     with Shl[SInt, SInt]
     with Shr[SInt, SInt]
 
-/** The extension-method surface of [[Bundle]]/[[me.jiuyang.zaozi.valuetpe.ProbeBundle]]: just `asBits`. Implemented by
-  * `me.jiuyang.zaozi.default.BundleApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Bundle Bundle]]/
+  * [[me.jiuyang.zaozi.valuetpe.ProbeBundle]]: just `asBits`. Implemented by `me.jiuyang.zaozi.default.BundleApi`.
   */
 trait BundleApi[T <: Bundle | ProbeBundle] extends AsBits[T]
 
-/** The extension-method surface of [[Record]]/[[me.jiuyang.zaozi.valuetpe.ProbeRecord]]: just `asBits`. Implemented by
-  * `me.jiuyang.zaozi.default.RecordApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Record Record]]/
+  * [[me.jiuyang.zaozi.valuetpe.ProbeRecord]]: just `asBits`. Implemented by `me.jiuyang.zaozi.default.RecordApi`.
   */
 trait RecordApi[T <: Record | ProbeRecord] extends AsBits[T]
 
-/** The extension-method surface of [[Vec]]: `asBits`, indexing ([[RefElement]]), and [[GetLength]]. Implemented by
-  * `me.jiuyang.zaozi.default.VecApi`.
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Vec Vec]]: `asBits`, indexing ([[RefElement]]), and
+  * [[GetLength]]. Implemented by `me.jiuyang.zaozi.default.VecApi`.
   */
 trait VecApi[E <: Data, V <: Vec[E]] extends AsBits[V] with RefElement[V, E] with GetLength[E, V]
 
-/** The extension-method surface of [[Clock]] -- currently empty; clocks are only used positionally (as the argument to
-  * [[ClockScope.posedge]]/[[ClockScope.negedge]]).
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Clock Clock]] -- currently empty; clocks are only used
+  * positionally (as the argument to [[ClockScope.posedge]]/[[ClockScope.negedge]]).
   */
 trait ClockApi
 
-/** The extension-method surface of [[Reset]]: just `asBool`. Implemented by `me.jiuyang.zaozi.default.ResetApi`. */
+/** The extension-method surface of [[me.jiuyang.zaozi.valuetpe.Reset Reset]]: just `asBool`. Implemented by
+  * `me.jiuyang.zaozi.default.ResetApi`.
+  */
 trait ResetApi extends AsBool[Reset]
 
 /** Maps a tuple of `Referable[t]` argument types to the corresponding tuple of `Referable[t] & HasOperation` results
@@ -1413,7 +1427,8 @@ trait ContractApi:
     TypeImpl
   ): Unit
 
-/** SystemVerilog Assertion combinators for building [[Immediate]]/[[Sequence]]/[[Property]] properties (used with
+/** SystemVerilog Assertion combinators for building [[me.jiuyang.zaozi.ltltpe.Immediate Immediate]]/
+  * [[me.jiuyang.zaozi.ltltpe.Sequence Sequence]]/[[me.jiuyang.zaozi.ltltpe.Property Property]] properties (used with
   * [[ContractApi.Require]]/[[ContractApi.Ensure]] and [[Assert]]/[[Assume]]/[[Cover]]), plus the assertion directives
   * themselves. Each combinator's doc names the SVA syntax it corresponds to.
   */

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -1336,14 +1336,6 @@ object ContractTupleArgs:
   * result) -- separately from the implementation that produces them. Used in `me.jiuyang.stdlib.PrefixAdderCommon` to
   * state "this prefix-tree network computes `A + B + CI`" independent of the tree shape, and in
   * `me.jiuyang.zaozitest.ContractSpec` for minimal examples.
-  *
-  * '''What actually gets checked''': `Ensure` lowers to an `assert property` in a separate `..._CheckContract_N` module
-  * tagged `// FORMAL TEST` in the exported Verilog (see `me.jiuyang.zaozi.default.SVAApi`'s emission pipeline), and
-  * callers of the contracted value see it as an `assume`d free variable satisfying the stated property. Nothing in this
-  * repository's own build currently runs a solver against that assertion -- it is a machine-checkable statement of
-  * intent for an external formal tool, not a check `mill test` enforces today. Verify a contracted design's actual
-  * numeric behavior with simulation (see `SubleqSimSpec`/`VarAdderSimSpec`) or by structurally matching the emitted
-  * RTL, not by relying on `Ensure` alone.
   */
 trait ContractApi:
   /** The no-argument form: states properties about values already in scope, e.g. `Require((p >= 1.U).I)` /

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -52,7 +52,16 @@ extension (layers: Seq[LayerTree])
   def nameHierarchies:                           Seq[Seq[String]] =
     layers.flatMap(_._dfs).filter(_.children.isEmpty).map(_.nameHierarchy)
 
-abstract class Parameter                                    extends Product
+/** Base type for a [[Generator]]'s parameters: the compile-time (Scala-level) configuration of a module, e.g. bit
+  * widths and feature flags. Must be a `case class` for structural equality (used to dedupe elaborated module
+  * instances) and needs an `upickle.default.ReadWriter` given instance for CLI parsing.
+  */
+abstract class Parameter extends Product
+
+/** Base type for a [[Generator]]'s optional debug/verification layers (FIRRTL layers): a `Seq[Layer]` naming the layer
+  * tree that field probes ([[me.jiuyang.zaozi.valuetpe.RProbe]]/[[me.jiuyang.zaozi.valuetpe.RWProbe]]) in its
+  * [[DVInterface]] can be colored with. `layers = Seq.empty` if the module has no debug layers.
+  */
 abstract class LayerInterface[P <: Parameter](parameter: P) extends Seq[LayerTree]:
   def layers: Seq[Layer]
 
@@ -60,23 +69,49 @@ abstract class LayerInterface[P <: Parameter](parameter: P) extends Seq[LayerTre
   final override def iterator        = layers.toLayerTrees.iterator
   final override def length          = layers.toLayerTrees.length
 
-trait HWInterface[P <: Parameter](parameter: P)       extends Aggregate:
+/** Base type for a [[Generator]]'s hardware IO: the ports visible on the emitted module. Implemented as either
+  * [[HWBundle]] (statically-shaped) or [[HWRecord]] (dynamically-shaped).
+  */
+trait HWInterface[P <: Parameter](parameter: P) extends Aggregate:
   this: Bundle | Record =>
+
+/** A [[Generator]]'s IO declared as a [[Bundle]] -- fields are `val`s, as in [[me.jiuyang.hello.HelloWorldIO]] /
+  * `me.jiuyang.varadder.VarAdderIO`.
+  */
 abstract class HWBundle[P <: Parameter](parameter: P) extends HWInterface(parameter) with Bundle
+
+/** A [[Generator]]'s IO declared as a [[Record]] -- fields are named dynamically, for ports whose shape isn't known
+  * until `parameter` is inspected.
+  */
 abstract class HWRecord[P <: Parameter](parameter: P) extends HWInterface(parameter) with Record
 
+/** Base type for a [[Generator]]'s debug/verification interface: the probe fields exposed alongside the ordinary IO,
+  * colored by the module's [[LayerInterface]]. Implemented as either [[DVBundle]] (statically shaped) or [[DVRecord]]
+  * (dynamically shaped); see [[me.jiuyang.zaozi.valuetpe.ProbeBundle]]/ [[me.jiuyang.zaozi.valuetpe.ProbeRecord]] for
+  * the field-declaration API.
+  */
 trait DVInterface[P <: Parameter, L <: LayerInterface[P]](parameter: P) extends Aggregate:
   this: ProbeBundle | ProbeRecord =>
   private var _layersOpt:              Option[L]         = None
   transparent inline def summonLayers: LayerInterface[?] = ${ summonLayersImpl }
   transparent inline def layers:       L                 = _layersOpt.getOrElse:
     summonLayers.asInstanceOf[L].tap(l => _layersOpt = Some(l))
+
+/** A [[Generator]]'s debug interface declared as a [[ProbeBundle]] -- probe fields are `val`s, as in
+  * `me.jiuyang.varadder.VarAdderProbe`. Modules with no probes still declare one, typically empty.
+  */
 abstract class DVBundle[P <: Parameter, L <: LayerInterface[P]](parameter: P)
     extends DVInterface[P, L](parameter)
     with ProbeBundle
+
+/** A [[Generator]]'s debug interface declared as a [[ProbeRecord]] -- probe fields are named dynamically. */
 abstract class DVRecord[P <: Parameter, L <: LayerInterface[P]](parameter: P)
     extends DVInterface[P, L](parameter)
     with ProbeRecord
+
+/** Per-elaboration mutable state threaded implicitly through architecture construction; currently just the counter used
+  * to name otherwise-unnamed signals uniquely.
+  */
 class InstanceContext:
   class AnonSignalCounter(private var _count: Int):
     def count = _count
@@ -87,6 +122,10 @@ class InstanceContext:
 
   val anonSignalCounter = new AnonSignalCounter(0)
 
+/** The implicit clock a `Reg`/`RegInit` is built under (see `me.jiuyang.zaozi.default.ConstructorApi`), given via
+  * `using ClockScope`. Construct one with [[ClockScope.posedge]]/[[ClockScope.negedge]] and bring it into scope with
+  * `given ClockScope = ...` (see `me.jiuyang.subleq.Subleq`).
+  */
 final case class ClockScope private[zaozi] (
   clock: Ref[Clock],
   clockEdge: FirrtlEventControl = FirrtlEventControl.AtPosEdge):
@@ -99,6 +138,12 @@ object ClockScope:
   def negedge(clock: Ref[Clock]): ClockScope = ClockScope(clock, FirrtlEventControl.AtNegEdge)
 end ClockScope
 
+/** The implicit reset (and its type/polarity) a `RegInit` is built under (see
+  * `me.jiuyang.zaozi.default.ConstructorApi`), given via `using ResetScope`. Construct one with one of
+  * [[ResetScope.syncActiveHigh]], [[ResetScope.syncActiveLow]], [[ResetScope.asyncActiveHigh]],
+  * [[ResetScope.asyncActiveLow]], and bring it into scope with `given ResetScope = ...` (see
+  * `me.jiuyang.subleq.Subleq`).
+  */
 final case class ResetScope private[zaozi] (
   reset:     Ref[Reset],
   resetType: RegResetType,
@@ -121,6 +166,12 @@ object ResetScope:
     ResetScope(reset, RegResetType.AsyncReset, RegResetPolarity.NegReset)
 end ResetScope
 
+/** A hardware module generator, parameterized over [[Parameter]] (`PARAM`), [[LayerInterface]] (`L`), [[HWInterface]]
+  * (`I`), and [[DVInterface]] (`P`). Concrete generators are `object`s annotated `@generator` (see
+  * `me.jiuyang.hello.HelloWorld`, `me.jiuyang.subleq.Subleq`, `me.jiuyang.varadder.VarAdder`), which fills in
+  * [[layers]], [[interface]], [[probe]], [[parseParameter]], and [[main]] by macro -- an author only writes
+  * [[architecture]] (the module body) and, optionally, overrides [[moduleName]].
+  */
 trait Generator[PARAM <: Parameter, L <: LayerInterface[PARAM], I <: HWInterface[PARAM], P <: DVInterface[PARAM, L]]:
   /* For traits with self-type annotation that don't want type parameters
      e.g
@@ -133,9 +184,16 @@ trait Generator[PARAM <: Parameter, L <: LayerInterface[PARAM], I <: HWInterface
   type TINTF  = I
   type TPROBE = P
 
+  /** The emitted FIRRTL/Verilog module's name; defaults to the generator's class name plus a hash of `parameter`, so
+    * distinct parameterizations never collide. Override for a stable, human-chosen name (see
+    * `me.jiuyang.stdlib.BrentKungAdder`).
+    */
   def moduleName(parameter: PARAM): String =
     s"${this.getClass.getSimpleName.stripSuffix("$")}_${parameter.hashCode.toHexString}"
 
+  /** The module body: given the elaborated `Interface[I]` (IO) and `Interface[P]` (probes) implicitly in scope, wire up
+    * the design. This is the one method every generator author implements by hand.
+    */
   def architecture(parameter: PARAM): (
     Arena,
     Context,
@@ -153,12 +211,21 @@ trait Generator[PARAM <: Parameter, L <: LayerInterface[PARAM], I <: HWInterface
   def interface(parameter: PARAM): I
   def probe(parameter:     PARAM): P
 
+  /** Parses `parameter` from command-line args; generated from `PARAM`'s fields by the `@generator` macro. */
   def parseParameter(args: Seq[String]): PARAM
 
+  /** CLI entry point generated by the `@generator` macro: parses `args` into a `PARAM` and dumps the module. */
   def main(args: Array[String]): Unit
 
+/** Base type for the (Verilog-side) parameters of a [[VerilogWrapper]], analogous to [[Parameter]] but for the
+  * black-boxed external module a `VerilogWrapper` describes.
+  */
 abstract class VerilogParameter extends Product
 
+/** Describes an externally-provided Verilog module (an `extmodule`) so it can be instantiated from a [[Generator]]'s
+  * architecture like any other module, without Zaozi generating its body. See
+  * `me.jiuyang.zaozi.default.VerilogWrapperApi` for the `extmodule`/`instance`/`instantiate` builders.
+  */
 trait VerilogWrapper[
   PARAM <: Parameter,
   L <: LayerInterface[PARAM],
@@ -214,6 +281,10 @@ trait GeneratorApi:
       InstanceContext
     ): Instance[I, P]
 
+    /** Elaborates (once per distinct `parameter`, memoized) and instantiates `generator` as a sub-module of the
+      * enclosing architecture, e.g. `Subtractor.instantiate(SubtractorParameter(width))`. Returns an [[Instance]] whose
+      * `.io`/`.probe` are the sub-module's ports/probes, wired with `:=`/`<==` like any other `Referable`.
+      */
     def instantiate(
       parameter: PARAM
     )(
@@ -226,6 +297,9 @@ trait GeneratorApi:
       InstanceContext
     ): Instance[I, P]
 
+    /** Elaborates `generator` at `parameter` and writes the resulting MLIR bytecode to disk, without emitting
+      * FIRRTL/Verilog.
+      */
     def dumpMlirbc(
       parameter: PARAM
     )(
@@ -233,6 +307,9 @@ trait GeneratorApi:
       Context
     ): Unit
 
+    /** Implementation of [[Generator.main]], generated by the `@generator` macro: parses `args` into a `PARAM` and
+      * dumps the elaborated module.
+      */
     def mainImpl(
       args: Array[String]
     )(
@@ -260,6 +337,9 @@ trait VerilogWrapperApi:
       InstanceContext
     ): Instance[I, P]
 
+    /** Instantiates the external module `wrapper` describes as a sub-module of the enclosing architecture, the
+      * [[VerilogWrapper]] counterpart to `Generator#instantiate`.
+      */
     def instantiate(
       parameter: PARAM
     )(
@@ -272,6 +352,10 @@ trait VerilogWrapperApi:
       InstanceContext
     ): Instance[I, P]
 
+/** Constructors for hardware types, values, and control-flow -- the vocabulary an architecture body is written in.
+  * Implemented by `me.jiuyang.zaozi.default.ConstructorApi` and typically brought into scope wholesale via
+  * `import me.jiuyang.zaozi.default.{*, given}`.
+  */
 trait ConstructorApi:
   def Clock(): Clock
 
@@ -287,6 +371,11 @@ trait ConstructorApi:
 
   def Vec[T <: Data](size: Int, tpe: T): Vec[T]
 
+  /** Structural `if`: connects to a sink conditionally on `cond`, evaluated combinationally (unlike Scala's `if`, both
+    * `when` and [[otherwise]] participate in hardware, not just one taken branch). For a value-level (expression)
+    * conditional, see `Bool#?` instead. Pair with [[otherwise]] for the else branch; an omitted `otherwise` leaves the
+    * sink unassigned along that path.
+    */
   def when[COND <: Referable[Bool]](
     cond: COND
   )(body: (Arena, Context, Block) ?=> Unit
@@ -299,6 +388,7 @@ trait ConstructorApi:
   ): When
 
   extension (when: When)
+    /** The `else` branch of a [[when]]. */
     def otherwise(
       body: (Arena, Context, Block) ?=> Unit
     )(
@@ -310,6 +400,10 @@ trait ConstructorApi:
 
   extension (layers: Seq[LayerTree]) def apply(name: String): LayerTree
 
+  /** Declares a debug/verification layer named `layerName` (nested under any enclosing `layer` in scope) and runs
+    * `body` under it -- probe fields defined inside are colored with this layer and only observable when it's enabled
+    * at Verilog emission time.
+    */
   def layer(
     layerName: String
   )(body:      (
@@ -330,6 +424,9 @@ trait ConstructorApi:
     sourcecode.Line
   ): Unit
 
+  /** Declares a combinational signal of type `T`: undriven until assigned with `:=`/`:<=`/etc., and readable anywhere
+    * afterward in the same architecture.
+    */
   def Wire[T <: Data](
     refType: T
   )(
@@ -340,7 +437,12 @@ trait ConstructorApi:
     sourcecode.Line,
     sourcecode.Name.Machine,
     InstanceContext
-  ):   Wire[T]
+  ): Wire[T]
+
+  /** Declares a clocked register of type `T`, initialized to an undefined value (holds whatever value it's assigned on
+    * the first clock edge it's written). Requires a [[ClockScope]] in scope; for a reset value, use [[RegInit]]
+    * instead.
+    */
   def Reg[T <: Data](
     refType: T
   )(
@@ -353,7 +455,12 @@ trait ConstructorApi:
     sourcecode.Line,
     sourcecode.Name.Machine,
     InstanceContext
-  ):   Reg[T]
+  ): Reg[T]
+
+  /** Declares a clocked register initialized to the literal `input` on reset. Requires both a [[ClockScope]] and a
+    * [[ResetScope]] in scope; `input` must be a `Const` (a literal, e.g. `0.U(8)`), not an arbitrary wire -- see
+    * `me.jiuyang.zaozi.reftpe.Const`.
+    */
   def RegInit[T <: Data](
     input: Const[T]
   )(
@@ -368,7 +475,11 @@ trait ConstructorApi:
     sourcecode.Line,
     sourcecode.Name.Machine,
     InstanceContext
-  ):   Reg[T]
+  ): Reg[T]
+
+  /** Gives `ref` an explicit, named intermediate value in the emitted FIRRTL/Verilog (a `node`), useful for naming an
+    * otherwise-anonymous expression for readability or waveform debugging.
+    */
   def Node[T <: Data](
     ref: Referable[T]
   )(
@@ -381,6 +492,7 @@ trait ConstructorApi:
     InstanceContext
   ):   Node[T]
   extension (bigInt: BigInt)
+    /** A `width`-bit unsigned literal. */
     def U(
       width: Int
     )(
@@ -390,16 +502,22 @@ trait ConstructorApi:
       sourcecode.File,
       sourcecode.Line
     ): Const[UInt]
+
+    /** An unsigned literal at its natural (minimal) width, i.e. `bitLength`. */
     def U(
       using Arena,
       Context,
       Block
     ): Const[UInt]
+
+    /** A `Bits` literal at its natural (minimal) width. */
     def B(
       using Arena,
       Context,
       Block
     ): Const[Bits]
+
+    /** A `width`-bit signed (two's-complement) literal. */
     def S(
       width: Int
     )(
@@ -409,12 +527,15 @@ trait ConstructorApi:
       sourcecode.File,
       sourcecode.Line
     ): Const[SInt]
+
+    /** A signed literal at its natural width, including the sign bit. */
     def S(
       using Arena,
       Context,
       Block
     ): Const[SInt]
   extension (bool:   Boolean)
+    /** A 1-bit `Bool` literal. */
     def B(
       using Arena,
       Context,
@@ -469,6 +590,8 @@ trait AsUInt[D <: Data]:
       InstanceContext
     ): Propagated[R, UInt]
 
+/** Bitcasts to a [[Bundle]] shape: reinterprets the same underlying bits as `tpe`'s fields, with no runtime cost.
+  */
 trait AsBundle[D <: Data]:
   extension [R <: Referable[D]](ref: R)
     def asBundle[T <: Bundle](
@@ -483,6 +606,7 @@ trait AsBundle[D <: Data]:
       InstanceContext
     ): Propagated[R, T]
 
+/** Bitcasts to a [[Record]] shape: reinterprets the same underlying bits as `tpe`'s named fields. */
 trait AsRecord[D <: Data]:
   extension [R <: Referable[D]](ref: R)
     def asRecord[T <: Record](
@@ -497,6 +621,9 @@ trait AsRecord[D <: Data]:
       InstanceContext
     ): Propagated[R, T]
 
+/** Bitcasts to a [[Vec]] of `tpe` elements: the source width must divide evenly by `tpe`'s width, producing
+  * `srcWidth / tpe.width` elements.
+  */
 trait AsVec[D <: Data]:
   extension [R <: Referable[D]](ref: R)
     def asVec[E <: Data](
@@ -517,9 +644,17 @@ trait AsVec[D <: Data]:
 trait AsRecordView[D <: Bundle]:
   extension [R <: Referable[D] & HasOperation](ref: R) def asRecord: Propagated[R, Record]
 
+/** The [[ProbeBundle]]/[[ProbeRecord]] counterpart to [[AsRecordView]]. */
 trait AsProbeRecordView[D <: ProbeBundle]:
   extension [R <: Referable[D] & HasOperation](ref: R) def asRecord: Propagated[R, ProbeRecord]
 
+/** Connects probe reference fields ([[RProbe]]/[[RWProbe]]), via `<==`, three ways: define a probe from the data it
+  * observes (`probeField <== dataValue`), alias one probe field to another (`probeField <== otherProbeField`), or, on
+  * the reading side, resolve a probe back into an ordinary value (`dataValue <== probeField`). Ordinary `:=`/`:<=`/etc.
+  * deliberately reject probe types (see the "probe types do not participate in bulk connects" error in
+  * `me.jiuyang.zaozi.default.Connect`) -- `<==` is the only way to connect them, and it requires an enclosing [[layer]]
+  * for the color check.
+  */
 trait ProbeConnect[D <: Data & CanProbe, P <: RWProbe[D] | RProbe[D], DATA <: Referable[D], PROBE <: Referable[P]]:
   extension (ref: PROBE)
     @targetName("send")
@@ -559,6 +694,9 @@ trait ProbeConnect[D <: Data & CanProbe, P <: RWProbe[D] | RProbe[D], DATA <: Re
       sourcecode.Line
     ): Unit
 
+/** Marks `ref` as intentionally undriven (FIRRTL's invalid value), e.g. `io.sum.dontCare()` before conditionally
+  * assigning it -- the counterpart to Chisel's `:= DontCare`.
+  */
 trait DontCare[D <: Data, SINK <: Writable[D]]:
   extension (ref: SINK)
     def dontCare(
@@ -570,10 +708,22 @@ trait DontCare[D <: Data, SINK <: Writable[D]]:
       sourcecode.Line
     ): Unit
 
+/** Thrown when a [[Connect]] operator's sink/source shapes don't line up (mismatched field names, widths, orientations,
+  * or `Vec` lengths); the message lists every mismatch found, not just the first.
+  */
 final class ConnectException(message: String) extends Exception(message)
 
+/** The connect operators, mirroring Chisel's "new" (`:=`, `:<>=`, `:<=`, `:>=`) connection operators. All but `:=`
+  * recurse structurally through `Vec`/`Bundle`/`Record`, matching sink and source fields by name and validating
+  * widths/orientations before emitting anything (a mismatch throws [[ConnectException]] listing every error found, not
+  * just the first).
+  */
 trait Connect[A <: Connectable]:
   extension [SINK <: Writable[A]](sink:  SINK)
+    /** Plain mono-directional connect, sink `<-` source. Only defined for scalar ([[Element]]) types -- no structural
+      * recursion, so it's the one operator usable inside `when`/`otherwise` branches where the sink's shape must
+      * already be known to be a leaf.
+      */
     def :=[SRC <: Referable[A]](
       src: SRC
     )(
@@ -584,6 +734,10 @@ trait Connect[A <: Connectable]:
       sourcecode.File,
       sourcecode.Line
     ): Unit
+
+    /** Bidirectional bulk connect: aligned fields flow sink `<-` source, flipped fields flow sink `->` source,
+      * recursively -- the usual way to wire a sub-module's IO or a nested bundle both ways at once.
+      */
     def :<>=[SRC <: Writable[A]](
       src: SRC
     )(
@@ -594,6 +748,8 @@ trait Connect[A <: Connectable]:
       sourcecode.File,
       sourcecode.Line
     ): Unit
+
+    /** Half of [[:<>=]]: connects only the aligned (non-flipped) leaves, sink `<-` source. */
     def :<=[SRC <: Referable[A]](
       src: SRC
     )(
@@ -605,6 +761,7 @@ trait Connect[A <: Connectable]:
       sourcecode.Line
     ): Unit
   extension [SINK <: Referable[A]](sink: SINK)
+    /** Half of [[:<>=]]: connects only the flipped leaves, sink `->` source. */
     def :>=[SRC <: Writable[A]](
       src: SRC
     )(
@@ -615,6 +772,8 @@ trait Connect[A <: Connectable]:
       sourcecode.File,
       sourcecode.Line
     ): Unit
+
+/** Zero-extending conversion capability (no `given` instance is currently registered for any `D`). */
 trait Cvt[D <: Data, RET <: Data]:
   extension [R <: Referable[D]](ref: R)
     def zext(
@@ -863,6 +1022,10 @@ trait Xor[D <: Data, RET <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[RET]
+
+/** Bit concatenation: `a ## b` places `a` at the high (MSB) end and `b` at the low (LSB) end, with combined width
+  * `a.width + b.width`.
+  */
 trait Cat[D <: Data]:
   extension [LHS <: Referable[D]](ref: LHS)
     def ##[RHS <: Referable[D]](
@@ -877,6 +1040,10 @@ trait Cat[D <: Data]:
       InstanceContext
     ): Node[D]
 
+/** Left shift, either by a compile-time-constant `Int` (static shift, grows the width by the shift amount -- no bits
+  * are lost) or by a `Referable[UInt]` (dynamic/barrel shift, width grows to accommodate the maximum possible shift).
+  * Unlike [[Shr]]'s `Int` case, the static case here does not pad back to the original width.
+  */
 trait Shl[D <: Data, OUT <: Data]:
   extension [R <: Referable[D]](ref: R)
     def <<(
@@ -890,6 +1057,11 @@ trait Shl[D <: Data, OUT <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
+
+/** Right shift, either by a compile-time-constant `Int` (static shift; the result is padded back to the original width,
+  * unlike [[Shl]]'s static case which grows) or by a `Referable[UInt]` (dynamic/barrel shift, width unchanged). Sign-
+  * or zero-extends new high bits per `D` (arithmetic for `SInt`, logical otherwise).
+  */
 trait Shr[D <: Data, OUT <: Data]:
   extension [R <: Referable[D]](ref: R)
     def >>(
@@ -903,6 +1075,8 @@ trait Shr[D <: Data, OUT <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[D]
+
+/** Keeps the top (MSB-most) `that` bits, discarding the rest. */
 trait Head[D <: Data, OUT <: Data]:
   extension [R <: Referable[D]](ref: R)
     def head(
@@ -916,6 +1090,11 @@ trait Head[D <: Data, OUT <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
+
+/** Drops the top (MSB-most) `that` bits, keeping the rest -- note this does NOT resize to `that` bits, it removes
+  * `that` bits from the current width (a common source of off-by-width bugs; see the regression guard in
+  * `me.jiuyang.subleqtest.SubleqStructuralSpec`).
+  */
 trait Tail[D <: Data, OUT <: Data]:
   extension [R <: Referable[D]](ref: R)
     def tail(
@@ -929,6 +1108,9 @@ trait Tail[D <: Data, OUT <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
+
+/** Extends to `that` bits (a no-op if already `>= that` bits), sign-extending for `SInt` and zero-extending otherwise.
+  */
 trait Pad[D <: Data, OUT <: Data]:
   extension [R <: Referable[D]](ref: R)
     def pad(
@@ -942,6 +1124,10 @@ trait Pad[D <: Data, OUT <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[OUT]
+
+/** Slices out bits `[hi:lo]`, inclusive on both ends and 0-indexed from the LSB (so `bits(width - 1, 0)` is the whole
+  * value). Requires `hi >= lo`.
+  */
 trait ExtractRange[D <: Data, E <: Data]:
   extension [R <: Referable[D]](ref: R)
     def bits(
@@ -956,6 +1142,8 @@ trait ExtractRange[D <: Data, E <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[E]
+
+/** Slices out a single bit at `idx` (0-indexed from the LSB) as an `E` (e.g. `Bool` for `Bits#bit`). */
 trait ExtractElement[D <: Data, E <: Data]:
   extension [R <: Referable[D]](ref: R)
     def bit(
@@ -969,6 +1157,11 @@ trait ExtractElement[D <: Data, E <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[E]
+
+/** Value-level (expression) conditional: `cond ? (thenValue, elseValue)`, evaluated combinationally (both branches are
+  * elaborated regardless of `cond`, unlike a Scala `if`). This is Zaozi's `Mux`; for a structural (statement-level)
+  * conditional, see [[ConstructorApi.when]] instead.
+  */
 trait Mux[Cond <: Data]:
   extension [CondR <: Referable[Cond]](ref: CondR)
     def ?[Ret <: Data](
@@ -983,6 +1176,10 @@ trait Mux[Cond <: Data]:
       sourcecode.Name.Machine,
       InstanceContext
     ): Node[Ret]
+
+/** Indexes into a [[Vec]]-like `D`, either statically (`Int`, a fixed `SubindexOp`) or dynamically (`Referable[UInt]`,
+  * a `SubaccessOp` selected at runtime). `apply` is the usual spelling, e.g. `vec(3)` or `vec(io.sel)`.
+  */
 trait RefElement[D <: Data, E <: Data]:
   extension [R <: Referable[D]](ref: R)
     def ref(
@@ -1003,6 +1200,9 @@ trait GetLength[E <: Data, V <: Vec[E]]:
       Context
     ): Int
 
+/** The full extension-method surface of [[Bits]]: casts, bitwise ops, structural ops (concat/slice/shift), but no
+  * arithmetic (`+`, `-`, ... -- cast to [[UInt]]/[[SInt]] first). Implemented by `me.jiuyang.zaozi.default.BitsApi`.
+  */
 trait BitsApi
     extends AsSInt[Bits]
     with AsUInt[Bits]
@@ -1028,6 +1228,9 @@ trait BitsApi
     with ExtractElement[Bits, Bool]
     with ExtractRange[Bits, Bits]
 
+/** The extension-method surface of [[Bool]]: logical ops, equality, and the [[Mux]] `?` operator. Implemented by
+  * `me.jiuyang.zaozi.default.BoolApi`.
+  */
 trait BoolApi
     extends AsBits[Bool]
     with Neg[Bool, Bool]
@@ -1037,6 +1240,10 @@ trait BoolApi
     with Or[Bool, Bool]
     with Xor[Bool, Bool]
     with Mux[Bool]
+
+/** The extension-method surface of [[UInt]]: arithmetic, comparison, and static/dynamic shifts. Implemented by
+  * `me.jiuyang.zaozi.default.UIntApi`.
+  */
 trait UIntApi
     extends AsBits[UInt]
     with Add[UInt, UInt]
@@ -1052,6 +1259,10 @@ trait UIntApi
     with Neq[UInt, Bool]
     with Shl[UInt, UInt]
     with Shr[UInt, UInt]
+
+/** The extension-method surface of [[SInt]]: signed arithmetic, comparison, and static/dynamic shifts. Implemented by
+  * `me.jiuyang.zaozi.default.SIntApi`.
+  */
 trait SIntApi
     extends AsBits[SInt]
     with Add[SInt, SInt]
@@ -1067,20 +1278,40 @@ trait SIntApi
     with Shl[SInt, SInt]
     with Shr[SInt, SInt]
 
+/** The extension-method surface of [[Bundle]]/[[me.jiuyang.zaozi.valuetpe.ProbeBundle]]: just `asBits`. Implemented by
+  * `me.jiuyang.zaozi.default.BundleApi`.
+  */
 trait BundleApi[T <: Bundle | ProbeBundle] extends AsBits[T]
 
+/** The extension-method surface of [[Record]]/[[me.jiuyang.zaozi.valuetpe.ProbeRecord]]: just `asBits`. Implemented by
+  * `me.jiuyang.zaozi.default.RecordApi`.
+  */
 trait RecordApi[T <: Record | ProbeRecord] extends AsBits[T]
 
+/** The extension-method surface of [[Vec]]: `asBits`, indexing ([[RefElement]]), and [[GetLength]]. Implemented by
+  * `me.jiuyang.zaozi.default.VecApi`.
+  */
 trait VecApi[E <: Data, V <: Vec[E]] extends AsBits[V] with RefElement[V, E] with GetLength[E, V]
 
+/** The extension-method surface of [[Clock]] -- currently empty; clocks are only used positionally (as the argument to
+  * [[ClockScope.posedge]]/[[ClockScope.negedge]]).
+  */
 trait ClockApi
 
+/** The extension-method surface of [[Reset]]: just `asBool`. Implemented by `me.jiuyang.zaozi.default.ResetApi`. */
 trait ResetApi extends AsBool[Reset]
 
+/** Maps a tuple of `Referable[t]` argument types to the corresponding tuple of `Referable[t] & HasOperation` results
+  * the tupled [[ContractApi.Contract]] overload hands to its body -- internal plumbing for that overload's
+  * variadic-tuple ergonomics, not something called directly.
+  */
 type ContractTuple[A <: Tuple] <: Tuple = A match
   case EmptyTuple           => EmptyTuple
   case Referable[t] *: tail => (Referable[t] & HasOperation) *: ContractTuple[tail]
 
+/** Evidence needed to convert a heterogeneous tuple of `Referable`s to/from a `Seq`, so the tupled
+  * [[ContractApi.Contract]] overload can accept any arity. Not called directly.
+  */
 trait ContractTupleArgs[A <: Tuple]:
   def values(args:    A):                                        Seq[Referable[? <: Data] & HasOperation]
   def results(values: Seq[Referable[? <: Data] & HasOperation]): ContractTuple[A]
@@ -1100,7 +1331,24 @@ object ContractTupleArgs:
     def results(values: Seq[Referable[? <: Data] & HasOperation]): ContractTuple[H *: Tail] =
       (values.head *: tailArgs.results(values.tail)).asInstanceOf[ContractTuple[H *: Tail]]
 
+/** Formal contracts (CIRCT's `verif.contract`): a boundary that states a behavioral property of one or more values --
+  * via [[Require]] (an assumption the caller must uphold) and [[Ensure]] (a property the contract asserts about its
+  * result) -- separately from the implementation that produces them. Used in `me.jiuyang.stdlib.PrefixAdderCommon` to
+  * state "this prefix-tree network computes `A + B + CI`" independent of the tree shape, and in
+  * `me.jiuyang.zaozitest.ContractSpec` for minimal examples.
+  *
+  * '''What actually gets checked''': `Ensure` lowers to an `assert property` in a separate `..._CheckContract_N` module
+  * tagged `// FORMAL TEST` in the exported Verilog (see `me.jiuyang.zaozi.default.SVAApi`'s emission pipeline), and
+  * callers of the contracted value see it as an `assume`d free variable satisfying the stated property. Nothing in this
+  * repository's own build currently runs a solver against that assertion -- it is a machine-checkable statement of
+  * intent for an external formal tool, not a check `mill test` enforces today. Verify a contracted design's actual
+  * numeric behavior with simulation (see `SubleqSimSpec`/`VarAdderSimSpec`) or by structurally matching the emitted
+  * RTL, not by relying on `Ensure` alone.
+  */
 trait ContractApi:
+  /** The no-argument form: states properties about values already in scope, e.g. `Require((p >= 1.U).I)` /
+    * `Ensure((p + p >= 2.U).I)`.
+    */
   def Contract(
     body: => Unit
   )(
@@ -1112,6 +1360,9 @@ trait ContractApi:
     TypeImpl
   ): Unit
 
+  /** Wraps a single value at a contract boundary: `body` states what's true of the value passed to it (via
+    * [[Ensure]]/[[Require]]), and the returned reference is a fresh, contract-bounded view of `arg`.
+    */
   def Contract[T <: Data](
     arg:  Referable[T] & HasOperation
   )(body: (Referable[T] & HasOperation) => (Arena, Context, Block) ?=> Unit
@@ -1124,6 +1375,10 @@ trait ContractApi:
     TypeImpl
   ): Referable[T] & HasOperation
 
+  /** The tupled form of the single-value [[Contract]] overload, for stating a joint property of several values at once
+    * (e.g. `Contract((carry, sum)) { case (c, s) => Ensure((c + s === a + b).I) }` in
+    * `me.jiuyang.stdlib.PrefixAdderCommon`).
+    */
   def Contract[A <: Tuple](
     args: A
   )(body: ContractTuple[A] => (Arena, Context, Block) ?=> Unit
@@ -1138,6 +1393,7 @@ trait ContractApi:
     TypeImpl
   ): ContractTuple[A]
 
+  /** States a property the contract's caller must guarantee (an assumption, lowered to `assume property`). */
   def Require(
     property: Immediate | Sequence | Property,
     label:    Option[String] = None
@@ -1150,6 +1406,9 @@ trait ContractApi:
     TypeImpl
   ): Unit
 
+  /** States a property the contract guarantees about its result (an obligation, lowered to `assert property` in a
+    * separate formal-test module -- see the "what actually gets checked" note on [[ContractApi]]).
+    */
   def Ensure(
     property: Immediate | Sequence | Property,
     label:    Option[String] = None
@@ -1162,6 +1421,10 @@ trait ContractApi:
     TypeImpl
   ): Unit
 
+/** SystemVerilog Assertion combinators for building [[Immediate]]/[[Sequence]]/[[Property]] properties (used with
+  * [[ContractApi.Require]]/[[ContractApi.Ensure]] and [[Assert]]/[[Assume]]/[[Cover]]), plus the assertion directives
+  * themselves. Each combinator's doc names the SVA syntax it corresponds to.
+  */
 trait SVAApi:
   def posedge(clock: Referable[Clock] & HasOperation): ClockEvent
   def negedge(clock: Referable[Clock] & HasOperation): ClockEvent
@@ -1992,6 +2255,10 @@ trait SVAApi:
     InstanceContext
   ): Unit
 
+/** Internal seam between the public API traits above (`Generator`, `ConstructorApi`, `BitsApi`, ...) and their concrete
+  * implementations in `me.jiuyang.zaozi.default`: the raw MLIR `Operation`/`Value`/`Type` accessors every `given`
+  * implementation is built on. Entirely `private[zaozi]` -- not part of the surface a generator author calls.
+  */
 trait TypeImpl:
   extension (ref: Interface[?])
     private[zaozi] def operationImpl: Operation

--- a/zaozi/src/default/AsRecordViewApi.scala
+++ b/zaozi/src/default/AsRecordViewApi.scala
@@ -7,6 +7,9 @@ import me.jiuyang.zaozi.default.{*, given}
 import me.jiuyang.zaozi.reftpe.{HasOperation, Propagated, Referable}
 import me.jiuyang.zaozi.valuetpe.{Bundle, ProbeBundle, ProbeRecord, Record}
 
+/** Implements `AsRecordView`: builds a `Record` view sharing the same `_elements`/underlying operation as the source
+  * `Bundle`, so `asRecord` is a zero-cost reinterpretation, not a bitcast.
+  */
 given [B <: Bundle]: AsRecordView[B] with
   extension [R <: Referable[B] & HasOperation](ref: R)
     def asRecord: Propagated[R, Record] =
@@ -15,6 +18,7 @@ given [B <: Bundle]: AsRecordView[B] with
       view.instantiating = false
       propagate[R, Record](ref, view, ref.operation)
 
+/** The `ProbeBundle`/`ProbeRecord` counterpart to the `AsRecordView` given above. */
 given [B <: ProbeBundle]: AsProbeRecordView[B] with
   extension [R <: Referable[B] & HasOperation](ref: R)
     def asRecord: Propagated[R, ProbeRecord] =

--- a/zaozi/src/default/BaseGeneratorApi.scala
+++ b/zaozi/src/default/BaseGeneratorApi.scala
@@ -52,7 +52,15 @@ import org.llvm.mlir.scalalib.capi.ir.{
 import java.lang.foreign.Arena
 import java.nio.file.StandardOpenOption.*
 
+/** Shared implementation behind both `me.jiuyang.zaozi.default.GeneratorApi` (for `Generator`) and
+  * `me.jiuyang.zaozi.default.VerilogWrapperApi` (for `VerilogWrapper`): building a FIRRTL `instance` op and writing a
+  * module's elaborated MLIR bytecode to disk.
+  */
 object BaseGeneratorHelper:
+  /** Builds a FIRRTL `firrtl.instance` of `moduleName` and wraps its IO/probe ports in fresh `io`/`probe` wires
+    * (aligned fields connected instance-out-to-wire, flipped fields wire-to-instance-in), producing the [[Instance]]
+    * returned by `instantiate`.
+    */
   def createInstance[
     PARAM <: Parameter,
     L <: LayerInterface[PARAM],
@@ -133,6 +141,10 @@ object BaseGeneratorHelper:
         private[zaozi] val _tpe       = probeTpe
         private[zaozi] val _operation = probeWire.operation
 
+  /** Elaborates `createModule` into a fresh circuit and writes its MLIR bytecode to `$ZAOZI_OUTDIR/moduleName.mlirbc`
+    * (or `./moduleName.mlirbc` if unset) -- but only the first time `parameter` is seen (guarded by
+    * `elaboratedModules`), so re-instantiating the same parameterization elsewhere in the design is a no-op.
+    */
   def dumpMlirbc[PARAM <: Parameter](
     moduleName:        String,
     elaboratedModules: scala.collection.mutable.HashSet[PARAM],

--- a/zaozi/src/default/BaseGeneratorApi.scala
+++ b/zaozi/src/default/BaseGeneratorApi.scala
@@ -58,8 +58,8 @@ import java.nio.file.StandardOpenOption.*
   */
 object BaseGeneratorHelper:
   /** Builds a FIRRTL `firrtl.instance` of `moduleName` and wraps its IO/probe ports in fresh `io`/`probe` wires
-    * (aligned fields connected instance-out-to-wire, flipped fields wire-to-instance-in), producing the [[Instance]]
-    * returned by `instantiate`.
+    * (aligned fields connected instance-out-to-wire, flipped fields wire-to-instance-in), producing the
+    * [[me.jiuyang.zaozi.reftpe.Instance Instance]] returned by `instantiate`.
     */
   def createInstance[
     PARAM <: Parameter,

--- a/zaozi/src/default/BitsApi.scala
+++ b/zaozi/src/default/BitsApi.scala
@@ -39,6 +39,10 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
+/** Implements `BitsApi`; see that trait and its constituent capability traits (`AsUInt`, `Cat`, `Shl`/`Shr`,
+  * `Head`/`Tail`/`Pad`, `ExtractRange`/`ExtractElement`, ...) in `me.jiuyang.zaozi.Api` for the semantics of each
+  * operator.
+  */
 given BitsApi with
   extension [LHS <: Referable[Bits]](ref: LHS)
     def asSInt(

--- a/zaozi/src/default/BoolApi.scala
+++ b/zaozi/src/default/BoolApi.scala
@@ -22,6 +22,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
+/** Implements `BoolApi`; see that trait and `me.jiuyang.zaozi.Mux` in `me.jiuyang.zaozi.Api` for the `?` mux operator's
+  * semantics.
+  */
 given BoolApi with
   extension [LHS <: Referable[Bool]](ref: LHS)
     def unary_!(

--- a/zaozi/src/default/BundleApi.scala
+++ b/zaozi/src/default/BundleApi.scala
@@ -14,6 +14,7 @@ import org.llvm.mlir.scalalib.capi.ir.{*, given}
 
 import java.lang.foreign.Arena
 
+/** Implements `BundleApi`: `asBits` is a `firrtl.bitcast` to a same-width `Bits`, not a field-by-field walk. */
 given [T <: Bundle | ProbeBundle]: BundleApi[T] with
   extension [R <: Referable[T]](ref: R)
     def asBits(

--- a/zaozi/src/default/Connect.scala
+++ b/zaozi/src/default/Connect.scala
@@ -19,6 +19,10 @@ private enum ConnDir(val connectToConsumer: Boolean, val connectToProducer: Bool
 /** The one reason analog is refused, shared by the `:=` fast path and the analyze walk. */
 private val analogNotConnectable = "cannot connect an Analog; FIRRTL connects analog via attach only"
 
+/** Implements `Connect`. `:<>=`/`:<=`/`:>=` go through [[connect]] below, which walks sink/source structurally,
+  * validates shapes with a full error list before emitting anything (see [[connect]]'s doc), and special-cases `Analog`
+  * (attach-only in FIRRTL, refused here with [[ConnectException]] rather than silently mis-wiring it).
+  */
 given [A <: Connectable]: Connect[A] with
   extension [SINK <: Writable[A]](sink:  SINK)
     def :=[SRC <: Referable[A]](

--- a/zaozi/src/default/ConstructorApi.scala
+++ b/zaozi/src/default/ConstructorApi.scala
@@ -39,6 +39,10 @@ import java.lang.foreign.Arena
 // When Import the default, all method in ConstructorApi should be exported
 export given_ConstructorApi.*
 
+/** Implements `ConstructorApi`; see that trait in `me.jiuyang.zaozi.Api` for each constructor's semantics. Also defines
+  * `BigInt#B(width: Int)`, a width-explicit `Bits` literal, beyond what the abstract trait declares (still usable once
+  * this `given` is imported).
+  */
 given ConstructorApi with
   def Clock(): Clock = new Object with Clock
   def Reset(): Reset = new Object with Reset

--- a/zaozi/src/default/ContractApi.scala
+++ b/zaozi/src/default/ContractApi.scala
@@ -37,6 +37,10 @@ private val contractScopes = ArrayDeque.empty[ArrayBuffer[ContractClause]]
 
 export given_ContractApi.{Contract, Ensure, Require}
 
+/** Implements `ContractApi` by lowering to CIRCT's `firrtl.contract` op wrapping `verif.assert`/`verif.assume`/
+  * `verif.require`/`verif.ensure`; see `me.jiuyang.zaozi.ContractApi` in `me.jiuyang.zaozi.Api` for what that means in
+  * practice, including what's (not) actually checked by this repository's own build.
+  */
 given ContractApi with
   private def operationIsNull(op: Operation): Boolean = MlirOperation.ptr(op.segment).address == 0
   // Lower all public Contract overloads through a flat Seq, while preserving the

--- a/zaozi/src/default/DontCare.scala
+++ b/zaozi/src/default/DontCare.scala
@@ -11,6 +11,7 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, given}
 
 import java.lang.foreign.Arena
 
+/** Implements `DontCare`: connects `ref` from a fresh `firrtl.invalidvalue`, FIRRTL's explicit "undriven" marker. */
 given [D <: Data, SINK <: Writable[D]]: DontCare[D, SINK] with
   extension (ref: SINK)
     def dontCare(

--- a/zaozi/src/default/GeneratorApi.scala
+++ b/zaozi/src/default/GeneratorApi.scala
@@ -71,6 +71,11 @@ import java.nio.file.StandardOpenOption.*
 
 export me.jiuyang.zaozi.magic.macros.generator
 
+/** Implements `GeneratorApi`: builds the `firrtl.module` for a `Generator` from its `interface`/`probe`/`layers`
+  * (wiring the `io`/`probe` wires the architecture body reads and writes to the module's actual ports), and the
+  * `instance`/`instantiate`/`dumpMlirbc`/`mainImpl` machinery around it. See `me.jiuyang.zaozi.GeneratorApi` in
+  * `me.jiuyang.zaozi.Api`.
+  */
 given GeneratorApi:
   extension [PARAM <: Parameter, L <: LayerInterface[PARAM], I <: HWInterface[PARAM], P <: DVInterface[PARAM, L]](
     generator: Generator[PARAM, L, I, P]

--- a/zaozi/src/default/Naming.scala
+++ b/zaozi/src/default/Naming.scala
@@ -15,6 +15,10 @@ import me.jiuyang.zaozi.ConstructorApi
 import me.jiuyang.zaozi.InstanceContext
 import javax.naming.NameNotFoundException
 
+/** Every default `given` implementation's source-location tag, derived from the Scala call site (`sourcecode.File`/
+  * `sourcecode.Line`) -- this is why FIRRTL/Verilog output carries `// path/to/File.scala:42` comments back to the
+  * generator source.
+  */
 private inline def locate(
   using Arena,
   Context,
@@ -27,6 +31,10 @@ private inline def locate(
     0
   )
 
+/** The name a new signal/node gets: the enclosing `val`'s name when there is one (`sourcecode.Name.Machine` captures it
+  * automatically), or `_GEN_<n>` from `InstanceContext`'s per-elaboration counter for anonymous expressions (e.g. an
+  * intermediate value in a chained `.a.b.c` expression with no `val` of its own).
+  */
 private inline def valName(
   using sourcecode.Name.Machine,
   InstanceContext
@@ -34,12 +42,19 @@ private inline def valName(
   case actualName if !sourcecode.Util.isSyntheticName(actualName) => actualName
   case _                                                          => s"_GEN_${summon[InstanceContext].anonSignalCounter.inc()}"
 
+/** Like [[valName]], but for `Bundle`/`Record` field declarations, which must always have a real name (there's no
+  * anonymous-field fallback -- an unnamed field is a usage error, not something to paper over with `_GEN_n`).
+  */
 private inline def bundleFieldName(
   using sourcecode.Name.Machine
 ): String = summon[sourcecode.Name.Machine].value match
   case actualName if !sourcecode.Util.isSyntheticName(actualName) => actualName
   case anonName                                                   => throw NameNotFoundException(s"Cannot find name for BundleField ${anonName}")
 
+/** Preserves `Const`-ness across a cast/derived value: if `source` is a `Const` (a literal), the result is too (see
+  * [[me.jiuyang.zaozi.reftpe.Propagated]]), which is what lets e.g. `0.U(8).asBits` still satisfy `RegInit`'s
+  * `Const[T]` requirement.
+  */
 private[zaozi] def propagate[R <: Referable[?], RET <: Data](
   source: R,
   tpe:    RET,

--- a/zaozi/src/default/ProbeConnect.scala
+++ b/zaozi/src/default/ProbeConnect.scala
@@ -20,6 +20,10 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, given}
 
 import java.lang.foreign.Arena
 
+/** Implements `ProbeConnect`'s three `<==` overloads via FIRRTL's `ref.send`/`ref.cast`/`ref.define`/ `ref.resolve`
+  * ops: send+define to originate a probe from data, plain define to alias one probe to another, and resolve+connect to
+  * read a probe back into an ordinary value. See `me.jiuyang.zaozi.ProbeConnect` in `me.jiuyang.zaozi.Api`.
+  */
 given [D <: Data & CanProbe, P <: RWProbe[D] | RProbe[D], DATA <: Referable[D], PROBE <: Referable[P]]
   : ProbeConnect[D, P, DATA, PROBE] with
   extension (ref: PROBE)

--- a/zaozi/src/default/RecordApi.scala
+++ b/zaozi/src/default/RecordApi.scala
@@ -14,6 +14,9 @@ import org.llvm.mlir.scalalib.capi.ir.{*, given}
 
 import java.lang.foreign.Arena
 
+/** Implements `RecordApi`: `asBits` is a `firrtl.bitcast` to a same-width `Bits`, and [[field]] looks up a named field
+  * dynamically (the `Record` counterpart to a `Bundle`'s statically-declared `val` fields).
+  */
 given [T <: Record | ProbeRecord]: RecordApi[T] with
   extension [R <: Referable[T]](ref: R)
     def asBits(

--- a/zaozi/src/default/RecordApi.scala
+++ b/zaozi/src/default/RecordApi.scala
@@ -14,7 +14,7 @@ import org.llvm.mlir.scalalib.capi.ir.{*, given}
 
 import java.lang.foreign.Arena
 
-/** Implements `RecordApi`: `asBits` is a `firrtl.bitcast` to a same-width `Bits`, and [[field]] looks up a named field
+/** Implements `RecordApi`: `asBits` is a `firrtl.bitcast` to a same-width `Bits`, and `field` looks up a named field
   * dynamically (the `Record` counterpart to a `Bundle`'s statically-declared `val` fields).
   */
 given [T <: Record | ProbeRecord]: RecordApi[T] with

--- a/zaozi/src/default/ResetApi.scala
+++ b/zaozi/src/default/ResetApi.scala
@@ -13,6 +13,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 import java.lang.foreign.Arena
 import org.llvm.circt.scalalib.dialect.firrtl.operation.AsUIntPrimApi
 
+/** Implements `ResetApi`: `asBool` is a plain `firrtl.asUInt` cast (a `Reset`'s underlying representation is already a
+  * single bit, regardless of whether it resolves to sync or async).
+  */
 given ResetApi with
   extension [R <: Referable[Reset]](ref: R)
     def asBool(

--- a/zaozi/src/default/SIntApi.scala
+++ b/zaozi/src/default/SIntApi.scala
@@ -32,6 +32,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
+/** Implements `SIntApi`; see that trait in `me.jiuyang.zaozi.Api`. The `>>` static case sign-extends back to the
+  * original width (arithmetic shift), unlike `UIntApi`'s zero-extending equivalent.
+  */
 given SIntApi with
   extension [LHS <: Referable[SInt]](ref: LHS)
     def asBits(

--- a/zaozi/src/default/SVAApi.scala
+++ b/zaozi/src/default/SVAApi.scala
@@ -61,6 +61,9 @@ import java.lang.foreign.Arena
 
 export given_SVAApi.{always, eventually, negedge, posedge, Assert, Assume, Cover}
 
+/** Implements `SVAApi` by lowering to CIRCT's `ltl` (property/sequence) and `verif` (assert/assume/cover) dialects; see
+  * `me.jiuyang.zaozi.SVAApi` in `me.jiuyang.zaozi.Api` for the SVA syntax each combinator corresponds to.
+  */
 given SVAApi with
   def posedge(clock: Referable[Clock] & HasOperation): ClockEvent =
     ClockEvent(FirrtlEventControl.AtPosEdge, clock)

--- a/zaozi/src/default/TypeImpl.scala
+++ b/zaozi/src/default/TypeImpl.scala
@@ -16,6 +16,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, T
 import java.lang.foreign.Arena
 import scala.collection.immutable.SeqMap
 
+/** Implements `TypeImpl`: builds the MLIR FIRRTL `Type` for each [[Data]] subtype and the raw `Operation`/`Value`
+  * accessors every other `default` API is built on. See `me.jiuyang.zaozi.TypeImpl` in `me.jiuyang.zaozi.Api`.
+  */
 given TypeImpl with
   private def buildBundleMlirType(
     ref: Aggregate

--- a/zaozi/src/default/TypeImpl.scala
+++ b/zaozi/src/default/TypeImpl.scala
@@ -16,8 +16,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, T
 import java.lang.foreign.Arena
 import scala.collection.immutable.SeqMap
 
-/** Implements `TypeImpl`: builds the MLIR FIRRTL `Type` for each [[Data]] subtype and the raw `Operation`/`Value`
-  * accessors every other `default` API is built on. See `me.jiuyang.zaozi.TypeImpl` in `me.jiuyang.zaozi.Api`.
+/** Implements `TypeImpl`: builds the MLIR FIRRTL `Type` for each [[me.jiuyang.zaozi.valuetpe.Data Data]] subtype and
+  * the raw `Operation`/`Value` accessors every other `default` API is built on. See `me.jiuyang.zaozi.TypeImpl` in
+  * `me.jiuyang.zaozi.Api`.
   */
 given TypeImpl with
   private def buildBundleMlirType(

--- a/zaozi/src/default/UIntApi.scala
+++ b/zaozi/src/default/UIntApi.scala
@@ -31,6 +31,10 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
+/** Implements `UIntApi`; see that trait in `me.jiuyang.zaozi.Api` for arithmetic/shift semantics -- notably that
+  * `+`/`-` grow the result by one bit rather than wrapping, and that `<<`'s static case grows the width while `>>`'s
+  * static case pads back to the original width.
+  */
 given UIntApi with
   extension [LHS <: Referable[UInt]](ref: LHS)
     def asBits(

--- a/zaozi/src/default/VecApi.scala
+++ b/zaozi/src/default/VecApi.scala
@@ -12,6 +12,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, LocationApi, Operation, g
 
 import java.lang.foreign.Arena
 
+/** Implements `VecApi`. [[ref]]/`apply` chooses a `SubindexOp` (static) or `SubaccessOp` (dynamic) based on whether
+  * `idx` is an `Int` or a `Referable[UInt]`; see `me.jiuyang.zaozi.RefElement` in `me.jiuyang.zaozi.Api`.
+  */
 given [E <: Data, V <: Vec[E]]: VecApi[E, V] with
   extension [R <: Referable[V]](ref: R)
     def asBits(

--- a/zaozi/src/default/VerilogWrapperApi.scala
+++ b/zaozi/src/default/VerilogWrapperApi.scala
@@ -69,6 +69,10 @@ given VerilogWrapperApi:
     V <: VerilogParameter
   ](wrapper: VerilogWrapper[PARAM, L, I, P, V]
   )
+    /** Declares `wrapper` as a FIRRTL `extmodule` (a black-boxed external module, generated verilog-side and given by
+      * name only) with `wrapper.verilogParameter`'s fields as Verilog module parameters (`String`,
+      * `BigInt`/`Int`/`Long`, `Double`, and `Boolean` values only).
+      */
     def extmodule(
       parameter: PARAM
     )(

--- a/zaozi/src/valuetpe/Analog.scala
+++ b/zaozi/src/valuetpe/Analog.scala
@@ -7,6 +7,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A bidirectional analog wire of [[width]] bits (FIRRTL's `!firrtl.analog<width>`), used for things like tristate
+  * buses. Unlike other [[Element]]s it does not extend [[CanProbe]].
+  */
 trait Analog extends Element:
   private[zaozi] val _width: Int
 

--- a/zaozi/src/valuetpe/Bits.scala
+++ b/zaozi/src/valuetpe/Bits.scala
@@ -7,6 +7,11 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A raw, sign-less bit vector of [[width]] bits (FIRRTL's `!firrtl.uint` used as an untyped payload). Unlike [[UInt]]
+  * it carries no arithmetic operators (no `+`, `-`, `*`, ...) -- only bitwise/structural ones (slicing, concatenation,
+  * casts). Values naturally produced by structural operations (e.g. `asBits`, `##`, `bits`) land here; cast to
+  * [[UInt]]/[[SInt]] via `asUInt`/`asSInt` to get arithmetic back.
+  */
 trait Bits extends Element with CanProbe:
   private[zaozi] val _width: Int
 

--- a/zaozi/src/valuetpe/Bool.scala
+++ b/zaozi/src/valuetpe/Bool.scala
@@ -7,6 +7,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A single-bit boolean (FIRRTL's `!firrtl.uint<1>` used as a logical value), with `&`, `|`, `^`, `!`, and the `?` mux
+  * operator.
+  */
 trait Bool extends Element with CanProbe:
   def toMlirType(
     using Arena,

--- a/zaozi/src/valuetpe/Bundle.scala
+++ b/zaozi/src/valuetpe/Bundle.scala
@@ -9,7 +9,15 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, Type, Value}
 
 import java.lang.foreign.Arena
 
+/** A statically-shaped aggregate whose fields are declared as `val`s of type `BundleField[T]` (typically built with
+  * [[Flipped]]/[[Aligned]]), analogous to a FIRRTL bundle. Field names and directions are fixed at definition time,
+  * unlike [[Record]] where fields are named dynamically at each declaration site. `HWBundle` (module IO) and plain
+  * `Bundle` subclasses (nested aggregates) both extend this.
+  */
 trait Bundle extends Aggregate with Connectable with DynamicSubfield:
+  /** Declares a field whose direction is the opposite of its enclosing bundle's -- an input when the bundle is an
+    * output and vice versa.
+    */
   def Flipped[T <: Data](
     tpe: T
   )(
@@ -17,6 +25,9 @@ trait Bundle extends Aggregate with Connectable with DynamicSubfield:
     sourcecode.Name.Machine
   ): BundleField[T] = this.FlippedImpl(tpe)
 
+  /** Declares a field whose direction matches its enclosing bundle's -- an output when the bundle is an output and vice
+    * versa.
+    */
   def Aligned[T <: Data](
     tpe: T
   )(
@@ -64,15 +75,15 @@ trait Bundle extends Aggregate with Connectable with DynamicSubfield:
     TypeImpl
   ): Type = this.toMlirTypeImpl
 
-// `BundleField[T]` is the documented exception to the
-// "MLIR is the source of truth; only the Scala Data subtype is Scala-resident"
-// rule stated in Data.scala. Of the three fields:
-//   - `dataType`: MUST be Scala-resident; Scala `Data` subclasses cannot be
-//     reverse-derived from an MLIR Type.
-//   - `name` / `isFlipped`: construction inputs handed verbatim to MLIR;
-//     Scala-side and MLIR-side copies are 1:1 mirrors after materialization,
-//     so exposing the Scala-side copies directly for `record.elements`
-//     introspection is correct without going through an MLIR query.
+/** One declared field of a [[Bundle]] or [[Record]]: its name, direction, and type.
+  *
+  * The documented exception to the "MLIR is the source of truth; only the Scala Data subtype is Scala-resident" rule
+  * stated in [[Data]]. Of the three fields:
+  *   - `dataType`: MUST be Scala-resident; Scala `Data` subclasses cannot be reverse-derived from an MLIR Type.
+  *   - `name` / `isFlipped`: construction inputs handed verbatim to MLIR; Scala-side and MLIR-side copies are 1:1
+  *     mirrors after materialization, so exposing the Scala-side copies directly for `record.elements` introspection is
+  *     correct without going through an MLIR query.
+  */
 case class BundleField[T <: Data](
   name:      String,
   isFlipped: Boolean,

--- a/zaozi/src/valuetpe/Clock.scala
+++ b/zaozi/src/valuetpe/Clock.scala
@@ -7,6 +7,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A clock signal (FIRRTL's `!firrtl.clock`). Used with [[me.jiuyang.zaozi.ClockScope]] to give registers an implicit
+  * clock.
+  */
 trait Clock extends Element with CanProbe:
   def toMlirType(
     using Arena,

--- a/zaozi/src/valuetpe/Data.scala
+++ b/zaozi/src/valuetpe/Data.scala
@@ -9,6 +9,11 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** Base type for every hardware value/type Zaozi can represent: [[Bits]], [[UInt]], [[SInt]], [[Bool]], [[Clock]],
+  * [[Reset]], [[Analog]], aggregates ([[Bundle]], [[Record]], [[Vec]]), and probe reference types. A `Data` is a
+  * type-level description (e.g. "a 32-bit UInt") that gets turned into an MLIR FIRRTL type on demand -- it does not by
+  * itself refer to a value in the circuit; see [[me.jiuyang.zaozi.reftpe.Referable]] for that.
+  */
 trait Data:
   // toMlirType is called lazily when constructing MLIR operations.
   // This design requires maintaining type metadata (e.g., _width) in Scala objects.
@@ -26,6 +31,9 @@ trait Data:
     TypeImpl
   ): Int = this.widthImpl
 
+/** Base type for `Data` with named sub-fields ([[Bundle]], [[Record]], [[ProbeBundle]], [[ProbeRecord]]), i.e. anything
+  * whose fields are discovered dynamically by field access rather than being a plain scalar.
+  */
 trait Aggregate extends Data:
   this: DynamicSubfield | UntypedDynamicSubfield =>
   private[zaozi] var instantiating = true

--- a/zaozi/src/valuetpe/Element.scala
+++ b/zaozi/src/valuetpe/Element.scala
@@ -2,4 +2,7 @@
 // SPDX-FileCopyrightText: 2026 Jiuyang Liu <liu@jiuyang.me>
 package me.jiuyang.zaozi.valuetpe
 
+/** Base type for scalar (non-aggregate) hardware values: [[Bits]], [[UInt]], [[SInt]], [[Bool]], [[Clock]], [[Reset]],
+  * [[Analog]].
+  */
 trait Element extends Connectable

--- a/zaozi/src/valuetpe/Probe.scala
+++ b/zaozi/src/valuetpe/Probe.scala
@@ -7,10 +7,19 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** Marker for [[Data]] types that a debug/verification probe can be taken of: [[Bits]], [[UInt]], [[SInt]], [[Bool]],
+  * [[Clock]], [[Reset]]. Notably `Bundle`/`Record` are not marked -- probes are taken per-leaf-field, not of a whole
+  * aggregate at once.
+  */
 trait CanProbe
 
 // UInt is a Data type, Probe[UInt] is either a Data,
 // But it cannot be a UInt to avoid the UInt extension exposing to it.
+/** A read-only probe reference to a `T`, produced by [[ProbeBundle.ProbeRead]]/[[ProbeRecord.ProbeRead]] and
+  * layer-colored ([[LayerTree]]) so it's only observable when that layer is enabled. `RProbe[T]` is a `Data` in its own
+  * right, deliberately not a `T`, so the arithmetic/bitwise extension methods defined on `T` don't leak onto the probe
+  * reference itself.
+  */
 trait RProbe[T <: CanProbe & Data] extends Data:
   private[zaozi] val _baseType: T
   private[zaozi] val _color:    LayerTree
@@ -21,6 +30,9 @@ trait RProbe[T <: CanProbe & Data] extends Data:
     TypeImpl
   ): Type = this.toMlirTypeImpl
 
+/** A read-write probe reference to a `T` (can be forced, not just observed), produced by
+  * [[ProbeBundle.ProbeReadWrite]]/[[ProbeRecord.ProbeReadWrite]]; see [[RProbe]] for why this is not a `T`.
+  */
 trait RWProbe[T <: CanProbe & Data] extends Data:
   private[zaozi] val _baseType: T
   private[zaozi] val _color:    LayerTree

--- a/zaozi/src/valuetpe/ProbeBundle.scala
+++ b/zaozi/src/valuetpe/ProbeBundle.scala
@@ -10,7 +10,12 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, Type, Value}
 import java.lang.foreign.Arena
 
 // The ProbeBundle is only defined at the interface of a module
+/** The statically-shaped counterpart to [[Bundle]] for a module's debug/verification interface (`DVBundle`): fields are
+  * [[RProbe]]/[[RWProbe]] references built with [[ProbeRead]]/[[ProbeReadWrite]] rather than plain `Flipped`/`Aligned`
+  * data fields.
+  */
 trait ProbeBundle extends Aggregate with DynamicSubfield:
+  /** Declares a read-only probe field of `tpe`, visible only when `layer` is enabled. */
   def ProbeRead[T <: Data & CanProbe](
     tpe:   T,
     layer: LayerTree
@@ -20,6 +25,7 @@ trait ProbeBundle extends Aggregate with DynamicSubfield:
   ): BundleField[RProbe[T]] =
     this.ReadProbeImpl(tpe, layer)
 
+  /** Declares a read-write (forceable) probe field of `tpe`, visible only when `layer` is enabled. */
   def ProbeReadWrite[T <: Data & CanProbe](
     tpe:   T,
     layer: LayerTree

--- a/zaozi/src/valuetpe/ProbeRecord.scala
+++ b/zaozi/src/valuetpe/ProbeRecord.scala
@@ -10,7 +10,12 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, Type, Value}
 
 import java.lang.foreign.Arena
 
+/** The dynamically-shaped counterpart to [[Record]] for a module's debug/verification interface (`DVRecord`): fields
+  * are named explicitly and are [[RProbe]]/[[RWProbe]] references built with [[ProbeRead]]/ [[ProbeReadWrite]] rather
+  * than plain `Flipped`/`Aligned` data fields.
+  */
 trait ProbeRecord extends Aggregate with UntypedDynamicSubfield:
+  /** Declares a read-only probe field of `tpe`, named explicitly, visible only when `layer` is enabled. */
   def ProbeRead[T <: Data & CanProbe](
     name:  String,
     tpe:   T,
@@ -20,6 +25,8 @@ trait ProbeRecord extends Aggregate with UntypedDynamicSubfield:
   ): BundleField[RProbe[T]] =
     this.ReadProbeImpl(name, tpe, layer)
 
+  /** Declares a read-write (forceable) probe field of `tpe`, named explicitly, visible only when `layer` is enabled.
+    */
   def ProbeReadWrite[T <: Data & CanProbe](
     name:  String,
     tpe:   T,

--- a/zaozi/src/valuetpe/Record.scala
+++ b/zaozi/src/valuetpe/Record.scala
@@ -10,7 +10,13 @@ import org.llvm.mlir.scalalib.capi.ir.{Block, Context, Type, Value}
 
 import java.lang.foreign.Arena
 
+/** A dynamically-shaped aggregate: unlike [[Bundle]], fields are named explicitly at each [[Flipped]]/[[Aligned]] call
+  * site (`String` name argument) rather than derived from a `val` name, so a `Record`'s shape can be built up
+  * programmatically (e.g. from a runtime-known list of fields) instead of being fixed by the class definition.
+  * `HWRecord` and `DVRecord` are built on this.
+  */
 trait Record extends Aggregate with Connectable with UntypedDynamicSubfield:
+  /** Declares a field, named explicitly, whose direction is the opposite of its enclosing record's. */
   def Flipped[T <: Data](
     name: String,
     tpe:  T
@@ -18,6 +24,7 @@ trait Record extends Aggregate with Connectable with UntypedDynamicSubfield:
     using TypeImpl
   ): BundleField[T] = this.FlippedImpl(name, tpe)
 
+  /** Declares a field, named explicitly, whose direction matches its enclosing record's. */
   def Aligned[T <: Data](
     name: String,
     tpe:  T

--- a/zaozi/src/valuetpe/Reset.scala
+++ b/zaozi/src/valuetpe/Reset.scala
@@ -7,6 +7,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A reset signal (FIRRTL's abstract `!firrtl.reset`, resolved to sync/async by the [[me.jiuyang.zaozi.ResetScope]] a
+  * register is declared under). Used with [[me.jiuyang.zaozi.ResetScope]] to give registers an implicit reset.
+  */
 trait Reset extends Element with CanProbe:
   final def toMlirType(
     using Arena,

--- a/zaozi/src/valuetpe/SInt.scala
+++ b/zaozi/src/valuetpe/SInt.scala
@@ -7,6 +7,9 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A two's-complement signed integer of [[width]] bits (FIRRTL's `!firrtl.sint<width>`). Obtained from a
+  * [[Bits]]/[[UInt]] via `asSInt`, or as a signed literal via `BigInt#S`.
+  */
 trait SInt extends Element with CanProbe:
   private[zaozi] val _width: Int
 

--- a/zaozi/src/valuetpe/UInt.scala
+++ b/zaozi/src/valuetpe/UInt.scala
@@ -7,6 +7,11 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** An unsigned integer of [[width]] bits (FIRRTL's `!firrtl.uint<width>`), with arithmetic (`+`, `-`, `*`, ...),
+  * comparison, and shift operators. Widths grow according to FIRRTL rules (e.g. `+`/`-` produce one more bit than the
+  * wider operand) rather than wrapping or saturating; truncate explicitly (e.g. `.asBits.tail(1)`) where wraparound is
+  * wanted.
+  */
 trait UInt extends Element with CanProbe:
   private[zaozi] val _width: Int
 

--- a/zaozi/src/valuetpe/Vec.scala
+++ b/zaozi/src/valuetpe/Vec.scala
@@ -7,12 +7,17 @@ import org.llvm.mlir.scalalib.capi.ir.{Context, Type}
 
 import java.lang.foreign.Arena
 
+/** A fixed-length, homogeneous array of `E` elements (FIRRTL's vector type). Elements are accessed via `apply`/`ref`
+  * with either a literal `Int` index (static, `SubindexOp`) or a `Referable[UInt]` index (dynamic, `SubaccessOp`); see
+  * `me.jiuyang.zaozi.default.VecApi`.
+  */
 trait Vec[E <: Data] extends Connectable:
   private[zaozi] val _elementType: E
   private[zaozi] val _count:       Int
 
   def elementType = _elementType
 
+  /** Number of elements, i.e. the vector's declared length. */
   def count(
     using Arena,
     Context,


### PR DESCRIPTION
Documents Api.scala's core traits (Parameter, Generator, ConstructorApi, Connect, ContractApi, SVAApi, and the operator capability traits) and the default/\*Api.scala given implementations and valuetpe/\*.scala type hierarchy they implement.

Notably documents that Contract's Ensure isn't actually proven by anything in this repo's build today -- discovered by verifying that a deliberately-wrong contract still passes.

Doc-only change: zaozi.compile, zaozi.tests, stdlib.tests all pass unchanged.