### PR TITLE
Add log2Ceil/log2Floor/isPow2 to the stdlib

### DIFF
--- a/stdlib/src/Util.scala
+++ b/stdlib/src/Util.scala
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+package me.jiuyang.stdlib
+
+// Plain Scala helpers at parameter-elaboration time -- Zaozi has no chisel3.util equivalent. Signatures mirror
+// chisel3.util's Util.scala (the BigInt overload is canonical; the Int overload is a convenience wrapper).
+
+/** The number of bits needed to represent `in` distinct values, i.e. `ceil(log2(in))`. `log2Ceil(1) == 0`. */
+def log2Ceil(in: BigInt): Int = { require(in > 0, "in must be positive"); (in - 1).bitLength }
+def log2Ceil(in: Int):    Int = log2Ceil(BigInt(in))
+
+/** The number of bits needed to represent the value `in`, i.e. `floor(log2(in))`. `log2Floor(1) == 0`. */
+def log2Floor(in: BigInt): Int = { require(in > 0, "in must be positive"); in.bitLength - 1 }
+def log2Floor(in: Int):    Int = log2Floor(BigInt(in))
+
+/** True if `in` is an exact power of 2. */
+def isPow2(in: BigInt): Boolean = in > 0 && (in & (in - 1)) == 0
+def isPow2(in: Int):    Boolean = isPow2(BigInt(in))

--- a/stdlib/tests/src/UtilSpec.scala
+++ b/stdlib/tests/src/UtilSpec.scala
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package me.jiuyang.stdlib
+
+import utest.*
+
+object UtilSpec extends TestSuite:
+  val tests = Tests:
+    test("log2Ceil"):
+      assert(log2Ceil(1) == 0)
+      assert(log2Ceil(2) == 1)
+      assert(log2Ceil(3) == 2)
+      assert(log2Ceil(4) == 2)
+      assert(log2Ceil(5) == 3)
+      assert(log2Ceil(1024) == 10)
+      assert(log2Ceil(BigInt(1) << 100) == 100)
+      intercept[IllegalArgumentException](log2Ceil(0))
+
+    test("log2Floor"):
+      assert(log2Floor(1) == 0)
+      assert(log2Floor(2) == 1)
+      assert(log2Floor(3) == 1)
+      assert(log2Floor(4) == 2)
+      assert(log2Floor(5) == 2)
+      assert(log2Floor(1024) == 10)
+      intercept[IllegalArgumentException](log2Floor(0))
+
+    test("isPow2"):
+      assert(isPow2(1))
+      assert(isPow2(2))
+      assert(!isPow2(3))
+      assert(isPow2(4))
+      assert(!isPow2(0))
+      assert(!isPow2(-4))
+      assert(isPow2(BigInt(1) << 100))


### PR DESCRIPTION
Plain Scala parameter-elaboration-time helpers mirroring chisel3.util's Util.scala -- Zaozi has no built-in equivalent, and my VarAdder had been carrying private copies of log2Ceil/isPow2 for lack of a shared home.
Chisel does have this, and it's useful.