### PR TITLE
build: SemanticDB emission, Scala 3.8.4, and a stable tooling compiler plugin (SemanticDB enhancement + PC navigation) for dynamic bundle fields

### DIFF
--- a/.github/workflows/jmh.yml
+++ b/.github/workflows/jmh.yml
@@ -19,4 +19,4 @@ jobs:
     runs-on: [self-hosted, linux, nixos]
     steps:
       - uses: actions/checkout@v4
-      - run: nix develop -c bash -c "mill --no-daemon --ticker false zaozi.benchmark.runJmh 2>&1 | grep -E '^Iteration|^Benchmark|^ZaoziBenchmark' > $GITHUB_STEP_SUMMARY"
+      - run: nix develop -c bash -c "mill --no-daemon --ticker false zaozi.benchmark.runJmh -wi 0 -i 1 -r 1s -f 1 2>&1 | grep -E '^Iteration|^Benchmark|^ZaoziBenchmark' > $GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .jvm-opts
 .mill-jvm-opts
 .metals/
+.scala3-bsp-semantic-ls/
+.zed/
 .vscode/
 .envrc
 .direnv/

--- a/build.mill
+++ b/build.mill
@@ -16,7 +16,7 @@ import contrib.jmh.JmhModule
 import os.Path
 
 object v {
-  val scala      = "3.7.4"
+  val scala      = "3.8.4"
   val mainargs   = mvn"com.lihaoyi::mainargs:0.7.6"
   val oslib      = mvn"com.lihaoyi::os-lib:0.11.3"
   val upickle    = mvn"com.lihaoyi::upickle:4.0.2"

--- a/build.mill
+++ b/build.mill
@@ -29,7 +29,16 @@ object v {
 
 trait ZaoziScalaModule extends ScalaModule {
   override def scalacOptions: T[Seq[String]] = Task(
-    super.scalacOptions() ++ Seq("-java-output-version", "25")
+    super.scalacOptions() ++ Seq(
+      "-java-output-version",
+      "25",
+      // Emit SemanticDB so the project can be indexed by SemanticDB-based
+      // tooling (Metals, scalafix, scala3-bsp-semantic-ls). Built into the
+      // Scala 3 compiler; -sourceroot keeps emitted URIs workspace-relative.
+      "-Xsemanticdb",
+      "-sourceroot",
+      mill.api.BuildCtx.workspaceRoot.toString
+    )
   )
 }
 

--- a/build.mill
+++ b/build.mill
@@ -37,8 +37,23 @@ trait ZaoziScalaModule extends ScalaModule {
       // Scala 3 compiler; -sourceroot keeps emitted URIs workspace-relative.
       "-Xsemanticdb",
       "-sourceroot",
-      mill.api.BuildCtx.workspaceRoot.toString
+      mill.api.BuildCtx.workspaceRoot.toString,
+      // Load the zaozi SemanticDB-enhancer plugin into every DSL module so
+      // bundle fields accessed through scala.Dynamic get real occurrences in
+      // the emitted SemanticDB. Mill only synthesizes -Xplugin flags for
+      // scalacPluginMvnDeps (published plugins), so a workspace-local plugin
+      // module is wired through its jar explicitly; ScalaTests forwards
+      // scalacOptions, so test modules inherit the plugin as well.
+      s"-Xplugin:${build.`zaozi-compiler-plugin`.jar().path}"
     )
+  )
+
+  // Also expose the plugin jar as a content-hashed input: the -Xplugin string
+  // above is path-only, so without this a plugin rebuild would not invalidate
+  // downstream compiles (mill hashes scalacPluginClasspath PathRefs into the
+  // compile inputs and zinc's compiler cache key).
+  override def scalacPluginClasspath: T[Seq[PathRef]] = Task(
+    super.scalacPluginClasspath() ++ Seq(build.`zaozi-compiler-plugin`.jar())
   )
 }
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -31,6 +31,24 @@ You can use `nix develop` to enter the development environment in the Nix flow,
 after you installed the dependencies and set the env. You can use
 `mill mill.bsp.BSP/install` to config BSP and open with Intellij IDEA or metal.
 
+### Zed
+
+Install the `scala3-bsp-semantic-ls` Zed adapter through the Nix-managed Zed
+configuration, then launch Zed from the project development environment:
+
+```shell
+nix develop --command zeditor .
+```
+
+Depending on the Zed installation, the command may be named `zed` instead of
+`zeditor`. Trust the worktree when Zed prompts for it so project settings and
+language servers are enabled. On Linux, the development shell hook generates
+the project-level `.zed/settings.json`, selecting the
+`scala3-bsp-semantic-ls` adapter and its exact Nix store binary path. Zed does
+not discover or download the server. The existing development-shell hook also
+generates `.bsp/mill-bsp.json`; the shared Mill module enables the SemanticDB
+options required by the server.
+
 ## Swap CIRCT for development
 Zaozi always follows the latest version of CIRCT. To use the specific version
 of CIRCT for development, you override the circt version in nix script. You can

--- a/flake.lock
+++ b/flake.lock
@@ -41,6 +41,21 @@
         "type": "github"
       }
     },
+    "crane": {
+      "locked": {
+        "lastModified": 1783203018,
+        "narHash": "sha256-G6R9IT/xwFuu+CYBWDUAok6AdC4ERC4ZfPPFtEpxnZE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "80db5bdc391be8a1794f6d8a2d56e3a84ebcede2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -60,6 +75,28 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "mill-ivy-fetcher",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "scala3-bsp-semantic-ls",
           "mill-ivy-fetcher",
           "nixpkgs"
         ]
@@ -114,6 +151,24 @@
         "type": "github"
       }
     },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "llvm-submodule-src": {
       "flake": false,
       "locked": {
@@ -136,6 +191,26 @@
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_2",
         "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1772960587,
+        "narHash": "sha256-JXcsEMWWoChpsCPuJQJaTdkEemC4Q5bcu3fPNTJvTGk=",
+        "owner": "Avimitin",
+        "repo": "mill-ivy-fetcher",
+        "rev": "54fbe54b4ad66d0dcefc240ed6388238c5fc1dfd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Avimitin",
+        "repo": "mill-ivy-fetcher",
+        "type": "github"
+      }
+    },
+    "mill-ivy-fetcher_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_4",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1772960587,
@@ -199,12 +274,67 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1765270179,
+        "narHash": "sha256-g2a4MhRKu4ymR4xwo+I+auTknXt/+j37Lnf0Mvfl1rE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "677fbe97984e7af3175b6c121f3c39ee5c8d62c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "circt-nix": "circt-nix",
         "flake-utils": "flake-utils_2",
         "mill-ivy-fetcher": "mill-ivy-fetcher",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_3",
+        "scala3-bsp-semantic-ls": "scala3-bsp-semantic-ls"
+      }
+    },
+    "scala3-bsp-semantic-ls": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_3",
+        "mill-ivy-fetcher": "mill-ivy-fetcher_2",
+        "nixpkgs": "nixpkgs_5",
+        "zaozi": "zaozi"
+      },
+      "locked": {
+        "lastModified": 1784561765,
+        "narHash": "sha256-1LObtWoGvfuXztmQnJ1T721fJpjifDStI8nc9LJa1yg=",
+        "owner": "xinpian-tech",
+        "repo": "scala3-bsp-semantic-ls",
+        "rev": "6e3a705da29ee24b00f1669cf25b957a3a3c51e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xinpian-tech",
+        "repo": "scala3-bsp-semantic-ls",
+        "type": "github"
       }
     },
     "slang-src": {
@@ -254,6 +384,21 @@
         "type": "github"
       }
     },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -272,6 +417,44 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "scala3-bsp-semantic-ls",
+          "mill-ivy-fetcher",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "zaozi": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782478578,
+        "narHash": "sha256-pQYHzckyC1XYIdf3hYZhPM0jIkMB8ffuB4FbTqVOAHg=",
+        "owner": "xinpian-tech",
+        "repo": "zaozi",
+        "rev": "fefb58e9a7d70d112cef3e7a891a849e43f3b43c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xinpian-tech",
+        "repo": "zaozi",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,7 @@
     circt-nix.url = "github:xinpian-tech/circt-nix/xinpian-main";
     flake-utils.url = "github:numtide/flake-utils";
     mill-ivy-fetcher.url = "github:Avimitin/mill-ivy-fetcher";
+    scala3-bsp-semantic-ls.url = "github:xinpian-tech/scala3-bsp-semantic-ls";
   };
 
   outputs =
@@ -17,6 +18,7 @@
       flake-utils,
       mill-ivy-fetcher,
       circt-nix,
+      scala3-bsp-semantic-ls,
       ...
     }:
     let
@@ -41,6 +43,24 @@
           ];
           inherit system;
         };
+        scala3BspSemanticLs = scala3-bsp-semantic-ls.packages.${system}.default;
+        zedSettings = pkgs.writeText "zaozi-zed-settings.json" ''
+          {
+            "languages": {
+              "Scala": {
+                "language_servers": ["scala3-bsp-semantic-ls"]
+              }
+            },
+            "lsp": {
+              "scala3-bsp-semantic-ls": {
+                "binary": {
+                  "path": "${scala3BspSemanticLs}/bin/scala3-bsp-semantic-ls",
+                  "arguments": []
+                }
+              }
+            }
+          }
+        '';
       in
       {
         formatter = pkgs.nixpkgs-fmt;
@@ -53,13 +73,18 @@
         };
         devShells.default = pkgs.mkShell {
           inputsFrom = [ pkgs.zaozi.zaozi-assembly ];
-          nativeBuildInputs = with pkgs; [ nixd jdk25 ];
+          nativeBuildInputs = with pkgs; [ nixd jdk25 ] ++ lib.optionals stdenv.isLinux [
+            scala3BspSemanticLs
+          ];
           env = with pkgs; {
             CIRCT_INSTALL_PATH = circt-install;
             MLIR_INSTALL_PATH = mlir-install;
             JEXTRACT_INSTALL_PATH = jextract;
             LIBC_INCLUDE_PATH = "${stdenv.cc.libc.dev}/include";
             LIT_INSTALL_PATH = lit;
+            # Share regular Mill outputs with BSP so SemanticDB produced by
+            # `mill __.compile` is immediately visible to the language server.
+            MILL_NO_SEPARATE_BSP_OUTPUT_DIR = "1";
             SCALA_CLI_INSTALL_PATH = scala-cli;
             RISCV_OPCODES_INSTALL_PATH = riscv-opcodes;
             Z3_LIB = "${z3.lib}/lib/libz3.so";
@@ -74,6 +99,9 @@
           # without it scalac throws StackOverflowError in pullOutFirstConstr.
           shellHook = ''
             export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Xss32m"
+            ${pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+              install -Dm644 ${zedSettings} .zed/settings.json
+            ''}
           '';
         };
       }

--- a/zaozi-compiler-plugin/package.mill
+++ b/zaozi-compiler-plugin/package.mill
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package build.`zaozi-compiler-plugin`
+
+import mill._
+import mill.scalalib._
+import mill.scalalib.scalafmt._
+
+import build.{v, ZaoziPublishModule}
+import build.zaozi
+
+// The SemanticDB-enhancer compiler plugin. Deliberately NOT a ZaoziScalaModule: that trait loads
+// this very plugin into scalac, which would make the plugin depend on its own jar.
+object `package` extends ScalaModule with ScalafmtModule with ZaoziPublishModule { m =>
+  def scalaVersion = Task(v.scala)
+
+  // Inside scalac the compiler classes are provided by the plugin classloader's parent, so the
+  // compiler must stay a compile-only dependency and not leak into the published runtime deps.
+  // plugin.properties (the scalac plugin descriptor) ships from the default resources/ directory.
+  def compileMvnDeps = Seq(mvn"org.scala-lang::scala3-compiler:${v.scala}")
+
+  object tests extends ScalaTests with ScalafmtModule with TestModule.Utest {
+    // The spec drives a real in-process scalac (dotty.tools.dotc.Main) over the fixture sources
+    // and parses the emitted .semanticdb protobufs, so it needs the compiler at runtime.
+    def mvnDeps = Seq(v.utest, v.oslib, mvn"org.scala-lang::scala3-compiler:${v.scala}")
+
+    // The fixtures are compiled (not run), so the test JVM only needs the classpath *string* of
+    // the zaozi DSL for the -classpath of the in-process compiler.
+    def forkEnv = Task {
+      super.forkEnv() ++ Map(
+        "ZAOZI_PLUGIN_JAR"        -> m.jar().path.toString,
+        "ZAOZI_FIXTURE_CLASSPATH" -> zaozi.runClasspath().map(_.path).mkString(java.io.File.pathSeparator),
+        "ZAOZI_FIXTURE_SOURCES"   -> (moduleDir / "resources" / "fixtures").toString
+      )
+    }
+  }
+}

--- a/zaozi-compiler-plugin/resources/plugin.properties
+++ b/zaozi-compiler-plugin/resources/plugin.properties
@@ -1,0 +1,1 @@
+pluginClass=me.jiuyang.zaozi.plugin.ZaoziSemanticDBPlugin

--- a/zaozi-compiler-plugin/src/dotty/tools/dotc/semanticdb/ZaoziSemanticdbFacade.scala
+++ b/zaozi-compiler-plugin/src/dotty/tools/dotc/semanticdb/ZaoziSemanticdbFacade.scala
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package dotty.tools.dotc.semanticdb
+
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Symbols.Symbol
+import dotty.tools.dotc.util.SourceFile
+import dotty.tools.dotc.util.Spans.Span
+
+/** Package-private access into `dotty.tools.dotc.semanticdb` for the zaozi SemanticDB enhancer plugin.
+  *
+  * The compiler's own symbol-naming ([[SemanticSymbolBuilder]]), range conversion and [[SymbolInformation]]
+  * construction helpers are `private[semanticdb]`. The plugin must emit symbol strings that are byte-identical to what
+  * `ExtractSemanticDB` itself would produce for a real `val` member (otherwise occurrences would not group with the
+  * definitions already present in the document), so instead of re-implementing the SemanticDB symbol grammar by string
+  * concatenation we open a small facade inside the package and delegate to the compiler's own implementation.
+  *
+  * Instances are cheap and must be scoped to a single compilation unit: [[SemanticSymbolBuilder]] numbers local symbols
+  * (`local0`, `local1`, ...) per document. The facade only guarantees stable names for global symbols; callers must
+  * check [[isGlobal]] before using [[symbolName]].
+  */
+final class ZaoziSemanticdbFacade(
+  using Context):
+  private given builder: SemanticSymbolBuilder = SemanticSymbolBuilder()
+  private given typeOps: TypeOps               = TypeOps()
+  private given LinkMode = LinkMode.SymlinkChildren
+
+  import Scala3.given
+
+  /** The SemanticDB symbol string the compiler itself would emit for `sym`. */
+  def symbolName(sym: Symbol): String = sym.symbolName
+
+  /** Whether `sym` gets a stable (non-`localN`) SemanticDB symbol. */
+  def isGlobal(sym: Symbol): Boolean = sym.isGlobal
+
+  /** The SemanticDB range for a span, converted exactly as `ExtractSemanticDB` does. */
+  def range(span: Span, source: SourceFile): Option[Range] = Scala3.range(span, source)
+
+  /** The `SymbolInformation` the compiler itself would emit for a `val` member. */
+  def valSymbolInformation(sym: Symbol): SymbolInformation =
+    sym.symbolInfo(Set(Scala3.SymbolKind.Val))

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziPcNavPhase.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziPcNavPhase.scala
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Contexts.Context
+import dotty.tools.dotc.core.Flags
+import dotty.tools.dotc.core.Names.termName
+import dotty.tools.dotc.core.Symbols.*
+import dotty.tools.dotc.core.Types.*
+import dotty.tools.dotc.plugins.PluginPhase
+
+import scala.annotation.tailrec
+import scala.util.control.NonFatal
+
+/** Presentation-compiler phase that makes go-to-definition and hover on a zaozi dynamic bundle-field access resolve to
+  * the real field declaration.
+  *
+  * A `Referable[T]` (`scala.Dynamic`) access `io.a` is a `transparent inline selectDynamic("a")` whose expansion drops
+  * the field name to a runtime string; the retained pre-inlining call `io.selectDynamic("a")` carries only the
+  * framework method symbol, so the compiler resolves `io.a` to `selectDynamic` rather than `val a`. This phase runs
+  * after `typer` (the inline expansion already happened there) and structurally rewrites the `Inlined.call` to a typed
+  * reference to the resolved field symbol, so the interactive symbol-at-cursor lookup returns the field.
+  *
+  * It is contributed by [[ZaoziSemanticDBPlugin.initialize]] ONLY to interactive presentation-compiler pipelines
+  * (parser/typer/SetRootTree/cookComments): the rewrite mutates the typed tree, so in the batch pipeline it would be
+  * pickled into published TASTy — batch compilations get the SemanticDB enhancer phase instead and this phase is never
+  * scheduled there. It keys strictly on the zaozi API (receiver derives from `me.jiuyang.zaozi.reftpe.Referable`, field
+  * owner from `me.jiuyang.zaozi.magic.DynamicSubfield`), so it is inert on foreign `scala.Dynamic` code, and every step
+  * is guarded so it can never fail an interactive request.
+  */
+class ZaoziPcNavPhase extends PluginPhase:
+  import ZaoziPcNavPhase.*
+
+  override val phaseName: String = ZaoziPcNavPhase.name
+
+  // Anchor on phases the interactive presentation compiler actually schedules (it runs only
+  // parser, typer, SetRootTree, cookComments); posttyper/inlining are absent there and would
+  // mis-schedule this phase.
+  override val runsAfter:  Set[String] = Set("typer")
+  override val runsBefore: Set[String] = Set("SetRootTree")
+
+  override def transformInlined(
+    tree: Inlined
+  )(
+    using Context
+  ): Tree =
+    try
+      fieldRefOf(tree.call) match
+        case Some(fieldRef) =>
+          // The primary path: this Inlined IS the dynamic access `io.a`. Point its retained call
+          // at the field so the symbol-at-cursor lookup returns it.
+          cpy.Inlined(tree)(fieldRef, tree.bindings, tree.expansion)
+        case None           =>
+          // Not itself a dynamic access, but its retained `call` (e.g. the whole `Tests { ... }`
+          // argument of an enclosing utest/macro `Inlined`) may hold typed COPIES of dynamic
+          // accesses. The megaphase never descends into `Inlined.call`, but interactive
+          // navigation (`NavigateAST.pathTo` via `productIterator`) does — and prefers the call
+          // over the expansion on span ties — so an un-rewritten copy there makes go-to land on
+          // the stale `selectDynamic`. Rewrite those copies too.
+          val call1 = rewriteRetainedCall(tree.call)
+          if call1 eq tree.call then tree
+          else cpy.Inlined(tree)(call1, tree.bindings, tree.expansion)
+    catch case NonFatal(_) => tree
+
+  /** A typed `ref` to the resolved bundle field if `call` is a zaozi dynamic field access, positioned at the access (so
+    * the cursor lands on the field name); else None.
+    */
+  private def fieldRefOf(
+    call: Tree
+  )(
+    using Context
+  ): Option[Tree] =
+    bundleFieldAccess(call).flatMap { (bundleType, fieldName) =>
+      resolveField(bundleType, fieldName).map(sym => ref(sym).withSpan(call.span))
+    }
+
+  /** Rewrite dynamic-access `Inlined` copies nested anywhere inside a retained inline/macro call, including the calls
+    * of further-nested `Inlined` nodes (which a plain `TreeMap` does not descend into).
+    */
+  private def rewriteRetainedCall(
+    call: Tree
+  )(
+    using Context
+  ): Tree =
+    if call.isEmpty then call
+    else
+      val mapper = new TreeMap:
+        override def transform(
+          t: Tree
+        )(
+          using Context
+        ): Tree = t match
+          case inl: Inlined =>
+            val innerCall = fieldRefOf(inl.call).getOrElse(transform(inl.call))
+            cpy.Inlined(inl)(innerCall, transformSub(inl.bindings), transform(inl.expansion))
+          case _ => super.transform(t)
+      mapper.transform(call)
+
+  /** `(bundleType, fieldName)` of a zaozi dynamic field access, from the retained pre-inlining call. Two shapes are
+    * recognized:
+    *   - `qual.selectDynamic("field")` — the retained call for `io.field`; the bundle is the `T` of the `Referable[T]`
+    *     receiver (the primary path).
+    *   - `bundle.getRefViaFieldValName[..](..)("field")` (and the optional variant) — the macro-expanded accessor, if
+    *     it is ever the retained call; the bundle is the accessor's `DynamicSubfield` receiver (defensive).
+    *
+    * `applyDynamic`/`applyDynamicNamed` (index/slice) are intentionally NOT matched, so `io.vec(i)`/`io.bits(hi, lo)`
+    * stay as identity.
+    */
+  private def bundleFieldAccess(
+    call: Tree
+  )(
+    using Context
+  ): Option[(Type, String)] =
+    call match
+      case Apply(Select(qual, sel), List(Literal(Constant(field: String)))) if sel.toString == "selectDynamic" =>
+        bundleOfReferable(qual.tpe.widen).map(t => (t, field))
+      case app @ Apply(fun, _) if accessorName(fun).isDefined                                                  =>
+        for
+          field  <- literalArg(app)
+          recv   <- accessorReceiver(fun)
+          bundle <- bundleOfReceiver(recv)
+        yield (bundle, field)
+      case _                                                                                                   => None
+
+  /** `T` of a `Referable[T]` receiver, when `T <: DynamicSubfield`. */
+  private def bundleOfReferable(
+    tpe: Type
+  )(
+    using Context
+  ): Option[Type] =
+    tpe.baseClasses.find(_.fullName.toString == ReferableName).flatMap { referable =>
+      tpe.baseType(referable).argInfos.headOption.filter(isDynamicSubfield)
+    }
+
+  /** Bundle type of a `getRefViaFieldValName` receiver: peel a leading `asInstanceOf[DynamicSubfield]` to recover the
+    * concrete pre-cast type.
+    */
+  private def bundleOfReceiver(
+    recv: Tree
+  )(
+    using Context
+  ): Option[Type] =
+    val tpe = recv match
+      case TypeApply(Select(inner, cast), _) if cast.toString == "asInstanceOf" => inner.tpe.widen
+      case _                                                                    => recv.tpe.widen
+    Option(tpe).filter(isDynamicSubfield)
+
+  private def isDynamicSubfield(
+    tpe: Type
+  )(
+    using Context
+  ): Boolean =
+    tpe.baseClasses.exists(_.fullName.toString == DynamicSubfieldName)
+
+  /** The bundle-field-accessor method name if `fun` selects one, else None. */
+  @tailrec
+  private def accessorName(
+    fun: Tree
+  )(
+    using Context
+  ): Option[String] =
+    fun match
+      case Select(_, name) if isAccessor(name.toString) => Some(name.toString)
+      case Apply(inner, _)                              => accessorName(inner)
+      case TypeApply(inner, _)                          => accessorName(inner)
+      case _                                            => None
+
+  @tailrec
+  private def accessorReceiver(
+    fun: Tree
+  )(
+    using Context
+  ): Option[Tree] =
+    fun match
+      case Select(recv, name) if isAccessor(name.toString) => Some(recv)
+      case Apply(inner, _)                                 => accessorReceiver(inner)
+      case TypeApply(inner, _)                             => accessorReceiver(inner)
+      case _                                               => None
+
+  private def isAccessor(name: String): Boolean =
+    name == "getRefViaFieldValName" || name == "getOptionRefViaFieldValName"
+
+  /** The first string-literal argument anywhere in a (possibly curried) apply. */
+  private def literalArg(
+    tree: Tree
+  )(
+    using Context
+  ): Option[String] =
+    def scan(t: Tree): Option[String] = t match
+      case Apply(fun, args)  =>
+        args.collectFirst { case Literal(Constant(s: String)) => s }.orElse(scan(fun))
+      case TypeApply(fun, _) => scan(fun)
+      case _                 => None
+    scan(tree)
+
+  /** Resolve `field` to a real, non-synthetic term member of the bundle type. */
+  private def resolveField(
+    bundleType: Type,
+    fieldName:  String
+  )(
+    using Context
+  ): Option[Symbol] =
+    val sym = bundleType.member(termName(fieldName)).symbol
+    Option.when(sym.exists && sym.isTerm && !sym.is(Flags.Synthetic))(sym)
+
+object ZaoziPcNavPhase:
+  val name: String = "zaoziPcNav"
+
+  /** The phases this phase orders itself against; the plugin only contributes it to pipelines that contain all of them
+    * and NO `posttyper` (see [[ZaoziSemanticDBPlugin.initialize]]).
+    */
+  val anchors: Set[String] = Set("typer", "SetRootTree")
+
+  private val ReferableName       = "me.jiuyang.zaozi.reftpe.Referable"
+  private val DynamicSubfieldName = "me.jiuyang.zaozi.magic.DynamicSubfield"

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
@@ -52,15 +52,36 @@ class ZaoziSemanticDBPlugin extends StandardPlugin:
   override val name:        String = "zaozi-semanticdb"
   override val description: String = "enhance SemanticDB with bundle-field occurrences for the zaozi hardware DSL"
 
+  /** Interactive-pipeline safety contract: the plugin jar travels on the modules' scalacOptions, so any dotty pipeline
+    * that honors `-Xplugin` will load this plugin — including the presentation compiler's `InteractiveDriver` (Metals,
+    * scala3-bsp-semantic-ls PC islands), whose pipeline is only parser/typer/SetRootTree/cookComments, and scaladoc. In
+    * such pipelines this phase's anchors do not exist, and `Plugins.schedule` throws `NoSuchElementException: key not
+    * found: extractSemanticDBExtractSemanticInfo` while propagating ordering constraints for names that are neither
+    * in-plan phases nor other plugin phases — aborting `InteractiveDriver` construction and thereby every IDE request
+    * (determined empirically on 3.8.4).
+    *
+    * `Run.compileUnits` calls `addPluginPhases(ctx.base.phasePlan)` after `rootContext` has set the plan of the active
+    * `Compiler`, so the pipeline is observable here: contribute the phase only when every anchor is present, and
+    * contribute nothing (a loaded but inert plugin) otherwise. SemanticDB extraction exists only in the batch pipeline,
+    * so nothing is lost.
+    */
   override def initialize(
     options: List[String]
   )(
     using Context
   ): List[PluginPhase] =
-    List(ZaoziSemanticDBPhase())
+    val planPhases = ctx.base.phasePlan.flatten.iterator.map(_.phaseName).toSet
+    if ZaoziSemanticDBPhase.anchors.subsetOf(planPhases) then List(ZaoziSemanticDBPhase())
+    else Nil
 
 object ZaoziSemanticDBPlugin:
   val phaseName: String = "zaoziSemanticdb"
+
+object ZaoziSemanticDBPhase:
+  /** The phases this plugin phase orders itself against; it must only be scheduled into pipelines that contain all of
+    * them (see [[ZaoziSemanticDBPlugin.initialize]]).
+    */
+  val anchors: Set[String] = Set("extractSemanticDBExtractSemanticInfo", "posttyper")
 
 class ZaoziSemanticDBPhase extends PluginPhase:
   override val phaseName: String = ZaoziSemanticDBPlugin.phaseName

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
@@ -1,0 +1,305 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.ast.tpd.*
+import dotty.tools.dotc.core.Constants.Constant
+import dotty.tools.dotc.core.Contexts.{ctx, Context}
+import dotty.tools.dotc.core.Names.termName
+import dotty.tools.dotc.core.StdNames.nme
+import dotty.tools.dotc.core.Symbols.{getClassIfDefined, ClassSymbol, NoSymbol, Symbol}
+import dotty.tools.dotc.core.Types.{AppliedType, NoType, Type}
+import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
+import dotty.tools.dotc.semanticdb.{
+  Range as SdbRange,
+  SymbolInformation,
+  SymbolOccurrence,
+  TextDocuments,
+  ZaoziSemanticdbFacade
+}
+import dotty.tools.dotc.util.{SourceFile, Spans}
+import dotty.tools.io.JarArchive
+
+import java.nio.file.{Files, Path, Paths}
+
+/** Zaozi SemanticDB enhancement plugin.
+  *
+  * Zaozi's hardware DSL accesses bundle fields through `scala.Dynamic`: `io.field` is rewritten by the typer to
+  * `io.selectDynamic("field")`, which is a transparent inline macro that expands to `getRefViaFieldValName` calls.
+  * Vanilla SemanticDB therefore records an occurrence of `Referable#selectDynamic().` at the `field` position instead
+  * of the bundle field itself, so SemanticDB-first tooling (scala3-bsp-semantic-ls, Metals, scalafix) cannot resolve
+  * go-to-definition or find-references for bundle fields.
+  *
+  * This [[StandardPlugin]] adds a single phase that runs right after the compiler's own
+  * `extractSemanticDBExtractSemanticInfo` phase (which writes the `.semanticdb` file for every compilation unit of the
+  * run *before* the next phase group starts) and before `posttyper` (so the tree still has exactly the shape the
+  * extractor saw). For each compilation unit it rewrites the dynamic-method occurrences to the SemanticDB symbol of the
+  * accessed bundle field `val`, using the compiler's own symbol naming so the occurrences group with the definitions
+  * the extractor already emitted for the defining `val`s.
+  *
+  * Design notes (deliberate differences from the earlier ResearchPlugin prototype, zaozi PR #91):
+  *   - Standard plugin on the stable compiler; no `-experimental`, no nightly pin.
+  *   - No global registry: all state lives in the single `run` invocation for the current unit, so long-lived zinc/mill
+  *     workers and incremental compilation cannot observe stale state.
+  *   - The field symbol is synthesized from the *receiver's type* (bundle class symbol -> member lookup), never from
+  *     same-run definition sites, so a usage file is enhanced correctly even when the defining file is not part of the
+  *     (incremental) run.
+  *   - Occurrences are rewritten only when both the range and the original dynamic-method symbol match what the tree
+  *     proves, keyed per span; same-named fields of unrelated bundles cannot collide.
+  *   - `-semanticdb-target` is honored using the same path computation as `ExtractSemanticDB`.
+  */
+class ZaoziSemanticDBPlugin extends StandardPlugin:
+  override val name:        String = "zaozi-semanticdb"
+  override val description: String = "enhance SemanticDB with bundle-field occurrences for the zaozi hardware DSL"
+
+  override def initialize(
+    options: List[String]
+  )(
+    using Context
+  ): List[PluginPhase] =
+    List(ZaoziSemanticDBPhase())
+
+object ZaoziSemanticDBPlugin:
+  val phaseName: String = "zaoziSemanticdb"
+
+class ZaoziSemanticDBPhase extends PluginPhase:
+  override val phaseName: String = ZaoziSemanticDBPlugin.phaseName
+
+  // `extractSemanticDBExtractSemanticInfo` writes the `.semanticdb` file of every unit in the run
+  // during its own `runOn`, i.e. strictly before this phase first runs; anchoring right after it
+  // (and before `posttyper`) keeps the tree byte-identical to what the extractor traversed, so all
+  // spans collected here line up with the occurrence ranges already in the document.
+  override val runsAfter:  Set[String] = Set("extractSemanticDBExtractSemanticInfo")
+  override val runsBefore: Set[String] = Set("posttyper")
+
+  override def isRunnable(
+    using Context
+  ): Boolean =
+    // Mirror ExtractSemanticDB.isRunnable: only useful when SemanticDB is being emitted, and the
+    // extractor does not write into jar outputs unless -semanticdb-target redirects elsewhere.
+    def writesToOutputJar =
+      ctx.settings.semanticdbTarget.value.isEmpty && ctx.settings.outputDir.value.isInstanceOf[JarArchive]
+    super.isRunnable && ctx.settings.Xsemanticdb.value && !writesToOutputJar
+
+  /** A bundle-field access through `Referable`'s dynamic methods, proven from the typed tree. */
+  private case class DynamicFieldUse(fieldSym: Symbol, dynamicSym: Symbol, span: Spans.Span)
+
+  /** A bundle-field `val` defined in the current unit. */
+  private case class FieldDef(fieldSym: Symbol, nameSpan: Spans.Span)
+
+  override def run(
+    using Context
+  ): Unit =
+    val referableCls       = getClassIfDefined("me.jiuyang.zaozi.reftpe.Referable")
+    val dynamicSubfieldCls = getClassIfDefined("me.jiuyang.zaozi.magic.DynamicSubfield")
+    val bundleFieldCls     = getClassIfDefined("me.jiuyang.zaozi.valuetpe.BundleField")
+    if !(referableCls.exists && dynamicSubfieldCls.exists && bundleFieldCls.exists) then return
+
+    val unit      = ctx.compilationUnit
+    val collector = Collector(referableCls.asClass, dynamicSubfieldCls.asClass, bundleFieldCls.asClass)
+    collector.traverse(unit.tpdTree)
+    if collector.uses.isEmpty && collector.defs.isEmpty then return
+
+    semanticdbPath(unit.source) match
+      case Some(path) if Files.exists(path) => enhance(path, unit.source, collector.defs.toList, collector.uses.toList)
+      case _                                => ()
+  end run
+
+  /** Collects bundle-field definitions and dynamic bundle-field accesses from the typed tree.
+    *
+    * Mirrors `ExtractSemanticDB.Extractor`'s traversal decision for inlined code: only the `call` part of an `Inlined`
+    * node is visited (the extractor never emits occurrences from expansions, so there is nothing to rewrite there
+    * either).
+    */
+  private final class Collector(referableCls: ClassSymbol, dynamicSubfieldCls: ClassSymbol, bundleFieldCls: ClassSymbol)
+      extends TreeTraverser:
+    val defs = collection.mutable.ListBuffer.empty[FieldDef]
+    val uses = collection.mutable.ListBuffer.empty[DynamicFieldUse]
+
+    override def traverse(
+      tree: Tree
+    )(
+      using Context
+    ): Unit =
+      tree match
+        case tree: Inlined =>
+          collectDynamicCall(tree.call)
+          traverse(tree.call)
+        case tree @ TypeDef(_, template: Template)
+            if tree.symbol.isClass && tree.symbol.derivesFrom(dynamicSubfieldCls) =>
+          template.body.foreach {
+            case vd: ValDef
+                if vd.symbol.exists && !vd.symbol.is(dotty.tools.dotc.core.Flags.Synthetic) &&
+                  isBundleFieldType(vd.symbol.info) && vd.nameSpan.exists && !vd.nameSpan.isZeroExtent =>
+              defs += FieldDef(vd.symbol, vd.nameSpan)
+            case _ => ()
+          }
+          traverseChildren(tree)
+        case _ =>
+          traverseChildren(tree)
+
+    /** `BundleField[?]` or `Option[BundleField[?]]`: the two shapes `selectDynamic` resolves. */
+    private def isBundleFieldType(
+      tp: Type
+    )(
+      using Context
+    ): Boolean =
+      val t = tp.widenDealias
+      t.derivesFrom(bundleFieldCls) ||
+      (t.derivesFrom(dotty.tools.dotc.core.Symbols.defn.OptionClass) && t.argInfos.exists(
+        _.derivesFrom(bundleFieldCls)
+      ))
+
+    /** Match the retained call of an inlined `Referable` dynamic application: `recv.selectDynamic("field")`,
+      * `recv.applyDynamic("field")(args*)`, `recv.applyDynamicNamed("field")(args*)`, with or without type arguments.
+      */
+    private def collectDynamicCall(
+      call: Tree
+    )(
+      using Context
+    ): Unit =
+      def unwrap(t: Tree): Option[(Select, Tree, String)] = t match
+        case Apply(fun, args) =>
+          fun match
+            case sel @ Select(recv, _) if isReferableDynamic(sel.symbol)               =>
+              args match
+                case Literal(Constant(fieldName: String)) :: _ => Some((sel, recv, fieldName))
+                case _                                         => None
+            case TypeApply(sel @ Select(recv, _), _) if isReferableDynamic(sel.symbol) =>
+              args match
+                case Literal(Constant(fieldName: String)) :: _ => Some((sel, recv, fieldName))
+                case _                                         => None
+            case fun: Apply => unwrap(fun)
+            case _                                                                     => None
+        case _                => None
+
+      unwrap(call).foreach { case (sel, recv, fieldName) =>
+        val nameSpan = sel.nameSpan
+        if nameSpan.exists && !nameSpan.isZeroExtent then
+          val fieldSym = fieldSymbolFor(recv, fieldName)
+          if fieldSym.exists then uses += DynamicFieldUse(fieldSym, sel.symbol, nameSpan)
+      }
+
+    private def isReferableDynamic(
+      sym: Symbol
+    )(
+      using Context
+    ): Boolean =
+      sym.exists && sym.owner == referableCls &&
+        (sym.name == nme.selectDynamic || sym.name == nme.applyDynamic || sym.name == nme.applyDynamicNamed)
+
+    /** Resolve the accessed field `val` from the receiver's type: `Referable[T]` gives the bundle type `T`; the field
+      * is its member with the accessed name and a `BundleField` type. Purely type-derived, so it works for bundles
+      * defined in other files or upstream jars.
+      */
+    private def fieldSymbolFor(
+      recv:      Tree,
+      fieldName: String
+    )(
+      using Context
+    ): Symbol =
+      recv.tpe.widenDealias.baseType(referableCls) match
+        case AppliedType(_, bundleTpe :: Nil) =>
+          val member = bundleTpe.member(termName(fieldName)).symbol
+          if member.exists && isBundleFieldType(member.info) then member else NoSymbol
+        case _                                => NoSymbol
+  end Collector
+
+  /** The `.semanticdb` path for `source`, computed exactly as `ExtractSemanticDB` does, honoring `-semanticdb-target`
+    * and falling back to the class output directory.
+    */
+  private def semanticdbPath(
+    source: SourceFile
+  )(
+    using Context
+  ): Option[Path] =
+    val targetSetting = ctx.settings.semanticdbTarget.value
+    val base: Option[Path] =
+      if targetSetting.nonEmpty then Some(Paths.get(targetSetting))
+      else
+        ctx.settings.outputDir.value match
+          case _: JarArchive => None
+          case outputDir => Option(outputDir.jpath)
+    base.map { base =>
+      base.toAbsolutePath.normalize
+        .resolve("META-INF")
+        .resolve("semanticdb")
+        .resolve(SourceFile.relativePath(source, ctx.settings.sourceroot.value))
+        .resolveSibling(source.name + ".semanticdb")
+    }
+
+  private def enhance(
+    path:   Path,
+    source: SourceFile,
+    defs:   List[FieldDef],
+    uses:   List[DynamicFieldUse]
+  )(
+    using Context
+  ): Unit =
+    val facade = ZaoziSemanticdbFacade()
+
+    // For every proven dynamic access: at this exact range, an occurrence of this exact dynamic
+    // method symbol must be rewritten to this exact field symbol. Local bundle classes get
+    // unreproducible `localN` symbols, so they are skipped.
+    case class Rewrite(dynamicSymbol: String, fieldSymbol: String)
+    val rewrites: Map[SdbRange, Rewrite] =
+      uses.flatMap { use =>
+        if !facade.isGlobal(use.fieldSym) then None
+        else
+          facade
+            .range(use.span, source)
+            .map(_ -> Rewrite(facade.symbolName(use.dynamicSym), facade.symbolName(use.fieldSym)))
+      }.toMap
+
+    // Definition-side records for fields defined in this unit. The extractor already emits both the
+    // DEFINITION occurrence and the SymbolInformation for these plain `val`s; this only repairs the
+    // document if a future compiler change stops doing so, and never duplicates existing records.
+    case class Definition(range: SdbRange, fieldSym: Symbol, fieldSymbol: String)
+    val definitions: List[Definition] =
+      defs.flatMap { d =>
+        if !facade.isGlobal(d.fieldSym) then None
+        else facade.range(d.nameSpan, source).map(Definition(_, d.fieldSym, facade.symbolName(d.fieldSym)))
+      }
+
+    if rewrites.isEmpty && definitions.isEmpty then return
+
+    val docs    = TextDocuments.parseFrom(Files.readAllBytes(path))
+    var changed = false
+    val updated = docs.documents.map { doc =>
+      val occurrences = doc.occurrences.map { occ =>
+        occ.range.flatMap(rewrites.get) match
+          case Some(rewrite) if occ.symbol == rewrite.dynamicSymbol && occ.role == SymbolOccurrence.Role.REFERENCE =>
+            changed = true
+            occ.copy(symbol = rewrite.fieldSymbol)
+          case _                                                                                                   => occ
+      }
+
+      val present      = occurrences.map(occ => (occ.range, occ.symbol, occ.role)).toSet
+      val presentInfos = doc.symbols.iterator.map(_.symbol).toSet
+
+      val missingUses = rewrites.collect {
+        case (range, rewrite)
+            if !present((Some(range), rewrite.fieldSymbol, SymbolOccurrence.Role.REFERENCE)) &&
+              !present((Some(range), rewrite.dynamicSymbol, SymbolOccurrence.Role.REFERENCE)) =>
+          SymbolOccurrence(Some(range), rewrite.fieldSymbol, SymbolOccurrence.Role.REFERENCE)
+      }.toList
+
+      val missingDefs = definitions.collect {
+        case d if !present((Some(d.range), d.fieldSymbol, SymbolOccurrence.Role.DEFINITION)) =>
+          SymbolOccurrence(Some(d.range), d.fieldSymbol, SymbolOccurrence.Role.DEFINITION)
+      }
+
+      val missingInfos = definitions.collect {
+        case d if !presentInfos(d.fieldSymbol) => facade.valSymbolInformation(d.fieldSym)
+      }.distinctBy(_.symbol)
+
+      if missingUses.nonEmpty || missingDefs.nonEmpty || missingInfos.nonEmpty then changed = true
+      doc.copy(
+        occurrences = occurrences ++ missingUses ++ missingDefs,
+        symbols = doc.symbols ++ missingInfos
+      )
+    }
+
+    if changed then Files.write(path, TextDocuments(updated).toByteArray)
+  end enhance
+end ZaoziSemanticDBPhase

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
@@ -30,12 +30,16 @@ import java.nio.file.{Files, Path, Paths}
   * of the bundle field itself, so SemanticDB-first tooling (scala3-bsp-semantic-ls, Metals, scalafix) cannot resolve
   * go-to-definition or find-references for bundle fields.
   *
-  * This [[StandardPlugin]] adds a single phase that runs right after the compiler's own
-  * `extractSemanticDBExtractSemanticInfo` phase (which writes the `.semanticdb` file for every compilation unit of the
-  * run *before* the next phase group starts) and before `posttyper` (so the tree still has exactly the shape the
-  * extractor saw). For each compilation unit it rewrites the dynamic-method occurrences to the SemanticDB symbol of the
-  * accessed bundle field `val`, using the compiler's own symbol naming so the occurrences group with the definitions
-  * the extractor already emitted for the defining `val`s.
+  * This [[StandardPlugin]] hosts the two pipeline-dispatched zaozi tooling phases (see [[initialize]] for the dispatch
+  * contract):
+  *   - batch: [[ZaoziSemanticDBPhase]], which runs right after the compiler's own
+  *     `extractSemanticDBExtractSemanticInfo` phase (which writes the `.semanticdb` file for every compilation unit of
+  *     the run *before* the next phase group starts) and before `posttyper` (so the tree still has exactly the shape
+  *     the extractor saw). For each compilation unit it rewrites the dynamic-method occurrences to the SemanticDB
+  *     symbol of the accessed bundle field `val`, using the compiler's own symbol naming so the occurrences group with
+  *     the definitions the extractor already emitted for the defining `val`s.
+  *   - interactive: [[ZaoziPcNavPhase]], which makes the presentation compiler's symbol-at-cursor (definition/hover)
+  *     resolve a dynamic access to the field declaration.
   *
   * Design notes (deliberate differences from the earlier ResearchPlugin prototype, zaozi PR #91):
   *   - Standard plugin on the stable compiler; no `-experimental`, no nightly pin.
@@ -50,28 +54,41 @@ import java.nio.file.{Files, Path, Paths}
   */
 class ZaoziSemanticDBPlugin extends StandardPlugin:
   override val name:        String = "zaozi-semanticdb"
-  override val description: String = "enhance SemanticDB with bundle-field occurrences for the zaozi hardware DSL"
+  override val description: String =
+    "zaozi tooling: SemanticDB bundle-field occurrences (batch) and PC bundle-field navigation (interactive)"
 
-  /** Interactive-pipeline safety contract: the plugin jar travels on the modules' scalacOptions, so any dotty pipeline
-    * that honors `-Xplugin` will load this plugin — including the presentation compiler's `InteractiveDriver` (Metals,
-    * scala3-bsp-semantic-ls PC islands), whose pipeline is only parser/typer/SetRootTree/cookComments, and scaladoc. In
-    * such pipelines this phase's anchors do not exist, and `Plugins.schedule` throws `NoSuchElementException: key not
-    * found: extractSemanticDBExtractSemanticInfo` while propagating ordering constraints for names that are neither
-    * in-plan phases nor other plugin phases — aborting `InteractiveDriver` construction and thereby every IDE request
-    * (determined empirically on 3.8.4).
+  /** Pipeline-dispatched phase contribution — the safety contract behind the single build-wired `-Xplugin` jar serving
+    * every dotty pipeline that loads it.
+    *
+    * The plugin jar travels on the modules' scalacOptions, so any dotty pipeline that honors `-Xplugin` loads this
+    * plugin: the batch compiler (zinc/mill), the interactive presentation compiler (`InteractiveDriver` — Metals and
+    * the scala3-bsp-semantic-ls PC islands; its pipeline is only parser/typer/SetRootTree/cookComments), scaladoc's
+    * tasty inspector (ReadTasty/TastyInspectorPhase), and the REPL (full batch pipeline). Contributing a phase whose
+    * `runsAfter`/`runsBefore` anchors are absent from the active plan makes `Plugins.schedule` throw
+    * `NoSuchElementException: key not found: <anchor>` while propagating ordering constraints — which aborts
+    * `InteractiveDriver` construction and thereby every IDE request (determined empirically on 3.8.4).
     *
     * `Run.compileUnits` calls `addPluginPhases(ctx.base.phasePlan)` after `rootContext` has set the plan of the active
-    * `Compiler`, so the pipeline is observable here: contribute the phase only when every anchor is present, and
-    * contribute nothing (a loaded but inert plugin) otherwise. SemanticDB extraction exists only in the batch pipeline,
-    * so nothing is lost.
+    * `Compiler`, so the pipeline is observable here, and each phase is contributed exactly to the pipeline it is meant
+    * for:
+    *   - Batch (plan has the SemanticDB extractor and `posttyper`): the [[ZaoziSemanticDBPhase]] enhancer only. The nav
+    *     phase must NEVER run here — it mutates the typed tree, and a batch mutation of `Inlined.call` would be pickled
+    *     into published TASTy.
+    *   - Interactive (plan has the nav anchors `typer`/`SetRootTree` but NO `posttyper` — the presence of `posttyper`
+    *     is what separates the batch/REPL pipelines, which also contain `SetRootTree`, from the interactive one): the
+    *     [[ZaoziPcNavPhase]] only. SemanticDB extraction does not exist there.
+    *   - Anything else (scaladoc's inspector has neither anchor set): nothing — a loaded but inert plugin.
     */
   override def initialize(
     options: List[String]
   )(
     using Context
   ): List[PluginPhase] =
-    val planPhases = ctx.base.phasePlan.flatten.iterator.map(_.phaseName).toSet
-    if ZaoziSemanticDBPhase.anchors.subsetOf(planPhases) then List(ZaoziSemanticDBPhase())
+    val planPhases  = ctx.base.phasePlan.flatten.iterator.map(_.phaseName).toSet
+    val batch       = ZaoziSemanticDBPhase.anchors.subsetOf(planPhases)
+    val interactive = ZaoziPcNavPhase.anchors.subsetOf(planPhases) && !planPhases.contains("posttyper")
+    if batch then List(ZaoziSemanticDBPhase())
+    else if interactive then List(ZaoziPcNavPhase())
     else Nil
 
 object ZaoziSemanticDBPlugin:

--- a/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixtureBundles.scala
+++ b/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixtureBundles.scala
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package fixtures
+
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.valuetpe.*
+
+class TestBundle extends Bundle:
+  val input  = Aligned(UInt(8))
+  val output = Flipped(UInt(8))
+  val flag   = Aligned(Bool())
+
+class OuterBundle extends Bundle:
+  val inner = Aligned(new TestBundle)
+  val data  = Aligned(UInt(32))
+  val maybe = Option.when(true)(Aligned(UInt(4)))
+
+case class FixtureParameter(width: Int) extends Parameter
+
+class FixtureIO(parameter: FixtureParameter) extends HWBundle(parameter):
+  val in     = Flipped(UInt(parameter.width))
+  val out    = Aligned(UInt(parameter.width))
+  val bundle = Aligned(new TestBundle)
+  val nested = Aligned(new OuterBundle)

--- a/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixturePlain.scala
+++ b/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixturePlain.scala
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package fixtures
+
+/** No bundles, no dynamic accesses: the plugin must leave this file's SemanticDB byte-identical. */
+object PluginFixturePlain:
+  val answer: Int = 42
+
+  def twice(n: Int): Int = n + n

--- a/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixtureUses.scala
+++ b/zaozi-compiler-plugin/tests/resources/fixtures/PluginFixtureUses.scala
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package fixtures
+
+import me.jiuyang.zaozi.{InstanceContext, TypeImpl}
+import me.jiuyang.zaozi.reftpe.{Interface, Referable}
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
+
+import java.lang.foreign.Arena
+
+/** Dynamic bundle-field accesses; the bodies never run, they only need to typecheck so that the
+  * `selectDynamic` macro expands and SemanticDB is emitted for the access sites.
+  */
+object PluginFixtureUses:
+  def throughReferable(
+    io: Referable[OuterBundle]
+  )(
+    using Arena,
+    Block,
+    Context,
+    TypeImpl,
+    InstanceContext
+  ): Unit =
+    val innerRef = io.inner
+    val dataRef  = io.data
+    val flagRef  = io.inner.flag
+    val maybeRef = io.maybe
+    ()
+
+  def throughInterface(
+    io: Interface[FixtureIO]
+  )(
+    using Arena,
+    Block,
+    Context,
+    TypeImpl,
+    InstanceContext
+  ): Unit =
+    val a = io.bundle.input
+    val b = io.nested.data
+    val c = io.out
+    ()

--- a/zaozi-compiler-plugin/tests/src/PluginSpec.scala
+++ b/zaozi-compiler-plugin/tests/src/PluginSpec.scala
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2025 Jiuyang Liu <liu@jiuyang.me>
+package me.jiuyang.zaozi.plugin
+
+import dotty.tools.dotc.semanticdb.{Range, SymbolOccurrence, TextDocument, TextDocuments}
+import utest.*
+
+/** Asserts the real `.semanticdb` output of the plugin.
+  *
+  * Each test drives an in-process scalac (`dotty.tools.dotc.Main`) with `-Xsemanticdb` and
+  * `-Xplugin:<the built plugin jar>` over the fixture sources, then parses the emitted protobuf documents and checks
+  * the injected records.
+  */
+object PluginSpec extends TestSuite:
+  private val pluginJar   = sys.env("ZAOZI_PLUGIN_JAR")
+  private val fixtureCp   = sys.env("ZAOZI_FIXTURE_CLASSPATH")
+  private val fixtureSrc  = os.Path(sys.env("ZAOZI_FIXTURE_SOURCES"))
+  private val scratchRoot = os.temp.dir(prefix = "zaozi-plugin-spec")
+
+  private val bundlesScala = "PluginFixtureBundles.scala"
+  private val usesScala    = "PluginFixtureUses.scala"
+  private val plainScala   = "PluginFixturePlain.scala"
+
+  private val selectDynamicSymbol = "me/jiuyang/zaozi/reftpe/Referable#selectDynamic()."
+
+  private def compile(
+    out:        os.Path,
+    sources:    Seq[String],
+    withPlugin: Boolean = true,
+    extraCp:    Seq[os.Path] = Nil,
+    extraFlags: Seq[String] = Nil
+  ): Unit =
+    os.makeDir.all(out)
+    val classpath = (fixtureCp +: extraCp.map(_.toString)).mkString(java.io.File.pathSeparator)
+    // -experimental: zaozi itself is compiled with -experimental, which marks its definitions
+    // @experimental for downstream code; fixtures consume zaozi like any user code does. The
+    // plugin itself neither needs nor uses experimental compiler API.
+    val args      =
+      Seq(
+        "-classpath",
+        classpath,
+        "-d",
+        out.toString,
+        "-experimental",
+        "-Xsemanticdb",
+        "-sourceroot",
+        fixtureSrc.toString
+      )
+        ++ (if withPlugin then Seq(s"-Xplugin:$pluginJar") else Nil)
+        ++ extraFlags
+        ++ sources.map(name => (fixtureSrc / name).toString)
+    val reporter  = dotty.tools.dotc.Main.process(args.toArray)
+    assert(!reporter.hasErrors)
+
+  private def semanticdbFile(base: os.Path, source: String): os.Path =
+    base / "META-INF" / "semanticdb" / s"$source.semanticdb"
+
+  private def readDoc(base: os.Path, source: String): TextDocument =
+    val docs = TextDocuments.parseFrom(os.read.bytes(semanticdbFile(base, source)))
+    assert(docs.documents.length == 1)
+    docs.documents.head
+
+  /** Slice the fixture source text at a SemanticDB range (0-based lines/columns). */
+  private def textAt(source: String, range: Range): String =
+    val lines = os.read(fixtureSrc / source).split("\n", -1)
+    assert(range.startLine == range.endLine)
+    lines(range.startLine).substring(range.startCharacter, range.endCharacter)
+
+  private def occurrencesOf(doc: TextDocument, symbol: String): Seq[SymbolOccurrence] =
+    doc.occurrences.filter(_.symbol == symbol)
+
+  /** Everything compiled once with the plugin; reused by the read-only assertions. */
+  private lazy val mainOut: os.Path =
+    val out = scratchRoot / "main"
+    compile(out, Seq(bundlesScala, usesScala, plainScala))
+    out
+
+  val tests = Tests {
+    test("definition SymbolInformation and DEFINITION occurrences per Aligned/Flipped field") {
+      val doc            = readDoc(mainOut, bundlesScala)
+      val expectedFields = Seq(
+        "fixtures/TestBundle#input."  -> "input",
+        "fixtures/TestBundle#output." -> "output",
+        "fixtures/TestBundle#flag."   -> "flag",
+        "fixtures/OuterBundle#inner." -> "inner",
+        "fixtures/OuterBundle#data."  -> "data",
+        "fixtures/OuterBundle#maybe." -> "maybe",
+        "fixtures/FixtureIO#in."      -> "in",
+        "fixtures/FixtureIO#out."     -> "out",
+        "fixtures/FixtureIO#bundle."  -> "bundle",
+        "fixtures/FixtureIO#nested."  -> "nested"
+      )
+      expectedFields.foreach { case (symbol, name) =>
+        // (a) SymbolInformation with the exact expected symbol string
+        assert(doc.symbols.exists(_.symbol == symbol))
+        // (b) exactly one DEFINITION occurrence, located precisely on the `val` name
+        val defs = occurrencesOf(doc, symbol).filter(_.role == SymbolOccurrence.Role.DEFINITION)
+        assert(defs.length == 1)
+        assert(textAt(bundlesScala, defs.head.range.get) == name)
+      }
+    }
+
+    test("REFERENCE occurrences at every dynamic access site") {
+      val doc      = readDoc(mainOut, usesScala)
+      val expected = Seq(
+        // (symbol, fieldNameInSource, occurrenceCount)
+        ("fixtures/OuterBundle#inner.", "inner", 2), // io.inner and io.inner.flag
+        ("fixtures/OuterBundle#data.", "data", 2),   // io.data and io.nested.data
+        ("fixtures/OuterBundle#maybe.", "maybe", 1), // Option[BundleField[_]] member
+        ("fixtures/TestBundle#flag.", "flag", 1),
+        ("fixtures/TestBundle#input.", "input", 1),  // io.bundle.input, cross-bundle chain
+        ("fixtures/FixtureIO#bundle.", "bundle", 1),
+        ("fixtures/FixtureIO#nested.", "nested", 1),
+        ("fixtures/FixtureIO#out.", "out", 1)
+      )
+      expected.foreach { case (symbol, name, count) =>
+        val refs = occurrencesOf(doc, symbol)
+        assert(refs.length == count)
+        refs.foreach { occ =>
+          assert(occ.role == SymbolOccurrence.Role.REFERENCE)
+          // (c) the range is exactly the field-name span of the `io.field` access
+          assert(textAt(usesScala, occ.range.get) == name)
+        }
+      }
+      // every selectDynamic occurrence was accounted for and rewritten
+      assert(occurrencesOf(doc, selectDynamicSymbol).isEmpty)
+    }
+
+    test("idempotence: recompilation produces identical records without duplicates") {
+      val doc1 = readDoc(mainOut, usesScala)
+      compile(mainOut, Seq(bundlesScala, usesScala, plainScala))
+      val doc2 = readDoc(mainOut, usesScala)
+      assert(doc1 == doc2)
+      // (d) no duplicate occurrences or symbol infos anywhere
+      Seq(bundlesScala, usesScala).foreach { source =>
+        val doc = readDoc(mainOut, source)
+        assert(doc.occurrences.distinct.length == doc.occurrences.length)
+        assert(doc.symbols.map(_.symbol).distinct.length == doc.symbols.length)
+      }
+    }
+
+    test("a file with no bundles is byte-identical to a plugin-less compile") {
+      val withPlugin    = scratchRoot / "plain-on"
+      val withoutPlugin = scratchRoot / "plain-off"
+      compile(withPlugin, Seq(plainScala), withPlugin = true)
+      compile(withoutPlugin, Seq(plainScala), withPlugin = false)
+      val on            = os.read.bytes(semanticdbFile(withPlugin, plainScala))
+      val off           = os.read.bytes(semanticdbFile(withoutPlugin, plainScala))
+      assert(java.util.Arrays.equals(on, off))
+    }
+
+    test("incremental: a usage file is enhanced without the defining file in the run") {
+      val defsOut = scratchRoot / "inc-defs"
+      val usesOut = scratchRoot / "inc-uses"
+      compile(defsOut, Seq(bundlesScala))
+      // Second, separate run: only the usage file, bundles come from the classpath.
+      compile(usesOut, Seq(usesScala), extraCp = Seq(defsOut))
+      val doc     = readDoc(usesOut, usesScala)
+      assert(occurrencesOf(doc, "fixtures/OuterBundle#inner.").length == 2)
+      assert(occurrencesOf(doc, "fixtures/TestBundle#input.").length == 1)
+      assert(occurrencesOf(doc, selectDynamicSymbol).isEmpty)
+    }
+
+    test("-semanticdb-target is honored") {
+      val out    = scratchRoot / "target-classes"
+      val target = scratchRoot / "target-semanticdb"
+      compile(out, Seq(bundlesScala, usesScala), extraFlags = Seq("-semanticdb-target", target.toString))
+      assert(!os.exists(semanticdbFile(out, usesScala)))
+      val doc    = readDoc(target, usesScala)
+      assert(occurrencesOf(doc, "fixtures/OuterBundle#inner.").nonEmpty)
+      assert(occurrencesOf(doc, selectDynamicSymbol).isEmpty)
+    }
+  }

--- a/zaozi-compiler-plugin/tests/src/PluginSpec.scala
+++ b/zaozi-compiler-plugin/tests/src/PluginSpec.scala
@@ -171,6 +171,106 @@ object PluginSpec extends TestSuite:
       assert(occurrencesOf(doc, selectDynamicSymbol).isEmpty)
     }
 
+    test("interactive: the nav phase resolves a dynamic access to the bundle field") {
+      // The PC island (and Metals) loads the plugin through the module's -Xplugin scalacOption;
+      // in the interactive pipeline the dispatched ZaoziPcNavPhase must rewrite the retained
+      // `Inlined.call` of `io.field1` into a typed ref of the field val, which is what makes
+      // symbol-at-cursor (definition/hover) land on `val field1 = Aligned(...)`.
+      val buffer =
+        """package navprobe
+          |
+          |import me.jiuyang.zaozi.*
+          |import me.jiuyang.zaozi.default.{*, given}
+          |import me.jiuyang.zaozi.reftpe.Referable
+          |import me.jiuyang.zaozi.valuetpe.*
+          |import org.llvm.mlir.scalalib.capi.ir.{Block, Context}
+          |
+          |import java.lang.foreign.Arena
+          |
+          |class NavBundle extends Bundle:
+          |  val field1 = Aligned(UInt(8))
+          |
+          |object NavUse:
+          |  def use(
+          |    io: Referable[NavBundle]
+          |  )(
+          |    using Arena,
+          |    Block,
+          |    Context,
+          |    TypeImpl,
+          |    InstanceContext
+          |  ): Unit =
+          |    val x = io.field1
+          |    ()
+          |""".stripMargin
+
+      // (rewrittenAccessTexts, selectDynamicCallCount) over every retained Inlined.call.
+      def inlinedCalls(withPlugin: Boolean): (List[String], Int) =
+        import dotty.tools.dotc.ast.tpd
+        import dotty.tools.dotc.core.Contexts.Context as DottyContext
+        val out            = scratchRoot / (if withPlugin then "nav-on" else "nav-off")
+        os.makeDir.all(out)
+        val options        = List("-classpath", fixtureCp, "-d", out.toString, "-experimental")
+          ++ (if withPlugin then List(s"-Xplugin:$pluginJar") else Nil)
+        val driver         = new dotty.tools.dotc.interactive.InteractiveDriver(options)
+        val uri            = java.net.URI.create(s"file:///NavProbe${if withPlugin then "On" else "Off"}.scala")
+        val diags          = driver.run(uri, dotty.tools.dotc.util.SourceFile.virtual(uri.toString, buffer))
+        assert(diags.isEmpty)
+        given DottyContext = driver.currentCtx
+        val fieldAccesses  = List.newBuilder[String]
+        var dynCalls       = 0
+        val traverser      = new tpd.TreeTraverser:
+          override def traverse(
+            tree: tpd.Tree
+          )(
+            using DottyContext
+          ): Unit = tree match
+            case inlined: tpd.Inlined =>
+              val callSym = inlined.call.symbol
+              if callSym.exists && callSym.name.toString == "field1" && callSym.owner.name.toString == "NavBundle"
+              then
+                val span = inlined.call.span
+                fieldAccesses += buffer.substring(span.start, span.end)
+              if callSym.exists && callSym.name.toString == "selectDynamic" then dynCalls += 1
+              traverse(inlined.call)
+              inlined.bindings.foreach(traverse)
+              traverse(inlined.expansion)
+            case _ => traverseChildren(tree)
+        traverser.traverse(driver.compilationUnits(uri).tpdTree)
+        (fieldAccesses.result(), dynCalls)
+
+      val (rewritten, dynLeft) = inlinedCalls(withPlugin = true)
+      // The retained call of the access is now a ref to NavBundle#field1, spanning the access.
+      assert(rewritten == List("io.field1"))
+      assert(dynLeft == 0)
+
+      val (baseline, dynBaseline) = inlinedCalls(withPlugin = false)
+      // Without the plugin the retained call still points at Referable#selectDynamic.
+      assert(baseline.isEmpty)
+      assert(dynBaseline > 0)
+    }
+
+    test("batch: tasty and bytecode are byte-identical with and without the plugin") {
+      // The nav phase must never even schedule in the batch pipeline (a batch rewrite of
+      // Inlined.call would be pickled into published TASTy), and the SemanticDB enhancer must
+      // never touch trees — so every .tasty/.class artifact must be byte-identical; only the
+      // .semanticdb payloads may differ.
+      val on                       = scratchRoot / "inert-on"
+      val off                      = scratchRoot / "inert-off"
+      compile(on, Seq(bundlesScala, usesScala), withPlugin = true)
+      compile(off, Seq(bundlesScala, usesScala), withPlugin = false)
+      def artifacts(base: os.Path) =
+        os.walk(base).filter(p => os.isFile(p) && (p.ext == "tasty" || p.ext == "class")).map(_.relativeTo(base))
+      val rels                     = artifacts(off)
+      assert(rels.nonEmpty)
+      assert(artifacts(on).toSet == rels.toSet)
+      rels.foreach { rel =>
+        val relPath   = rel.toString
+        val identical = java.util.Arrays.equals(os.read.bytes(on / rel), os.read.bytes(off / rel))
+        assert(identical, relPath.nonEmpty) // relPath in scope so a failure names the artifact
+      }
+    }
+
     test("interactive presentation-compiler pipeline stays functional with the plugin loaded") {
       // The PC island (and Metals) reuses the batch scalacOptions, so InteractiveDriver loads the
       // plugin too. Its pipeline (parser/typer/SetRootTree/cookComments) has none of the phase's

--- a/zaozi-compiler-plugin/tests/src/PluginSpec.scala
+++ b/zaozi-compiler-plugin/tests/src/PluginSpec.scala
@@ -170,4 +170,24 @@ object PluginSpec extends TestSuite:
       assert(occurrencesOf(doc, "fixtures/OuterBundle#inner.").nonEmpty)
       assert(occurrencesOf(doc, selectDynamicSymbol).isEmpty)
     }
+
+    test("interactive presentation-compiler pipeline stays functional with the plugin loaded") {
+      // The PC island (and Metals) reuses the batch scalacOptions, so InteractiveDriver loads the
+      // plugin too. Its pipeline (parser/typer/SetRootTree/cookComments) has none of the phase's
+      // anchors; the plugin must contribute no phases there instead of crashing Plugins.schedule
+      // (NoSuchElementException: key not found: extractSemanticDBExtractSemanticInfo) during
+      // driver construction.
+      val out    = scratchRoot / "interactive-out"
+      os.makeDir.all(out)
+      val driver = new dotty.tools.dotc.interactive.InteractiveDriver(
+        List("-classpath", fixtureCp, "-d", out.toString, "-experimental", s"-Xplugin:$pluginJar")
+      )
+      val uri    = java.net.URI.create("file:///InteractiveProbe.scala")
+      val code   = "class InteractiveProbe { val x: Int = 1; def f: Int = x }"
+      val diags  = driver.run(uri, dotty.tools.dotc.util.SourceFile.virtual(uri.toString, code))
+      assert(diags.isEmpty)
+      val unit   = driver.compilationUnits.get(uri)
+      assert(unit.isDefined)
+      assert(!unit.get.tpdTree.isEmpty)
+    }
   }


### PR DESCRIPTION
## What

Five commits that make zaozi fully navigable by SemanticDB-based tooling — Metals, scalafix, and the scala3-bsp-semantic-ls language server — including the **dynamically-accessed bundle fields** that macros normally erase from SemanticDB:

1. **`build: emit SemanticDB`** — `-Xsemanticdb` + `-sourceroot <workspaceRoot>` on every `ZaoziScalaModule`.
2. **`build: bump Scala to 3.8.4`** — aligns the workspace with the compiler the LSP's presentation-compiler island and SemanticDB tooling pin, so tasty/SemanticDB/PC behavior is same-version end to end and downstream consumers stop carrying a version patch. Zero source changes needed (full suite green); `-java-output-version 25` remains valid (the dev-shell JDK is 25; 3.8.4's backend maps up to classfile 26).
3. **`feat(zaozi-compiler-plugin)`** — absorbs and supersedes #91: a compiler plugin that injects the SemanticDB occurrences the `Dynamic`/`transparent inline` expansion drops, so `io.field` accesses get real go-to-definition/find-references.
4. **`fix(zaozi-compiler-plugin): stay inert in pipelines without the anchors`** — the interactive-pipeline safety contract (details below).
5. **`feat(zaozi-compiler-plugin): fold PC bundle-field navigation into the plugin`** — the plugin now carries a second, pipeline-dispatched phase: in the presentation compiler's interactive pipeline it rewrites the retained `Inlined.call` of a dynamic access so symbol-at-cursor (go-to-definition, hover) resolves the real `val field = Aligned/Flipped(...)`. One build-wired `-Xplugin` jar therefore serves both worlds — batch SemanticDB enhancement for the index, interactive navigation for any LSP client's presentation compiler — with no editor-side plugin configuration.

**Pipeline dispatch** (empirically grounded): `SetRootTree` is *not* an interactive discriminator — batch and REPL pipelines contain it too; the load-bearing exclusion is **`posttyper`**. `initialize` probes the active phase plan: batch/REPL (has `posttyper`) → enhancer only; interactive (nav anchors present, no `posttyper`) → nav only; scaladoc/TastyInspector (neither) → inert. The nav phase is proven **batch-inert** by byte-identical `.tasty`/`.class` artifacts with and without the plugin — a batch tree rewrite would otherwise be pickled into published tasty.

## How this differs from #91 (absorbed, redesigned)

#91 proved the idea but used the **`ResearchPlugin`** API — which forced a NIGHTLY compiler pin, a custom repository bootstrap, and `-experimental`. This PR lands the same capability as a **`StandardPlugin` on stock Scala 3.8.4**:

- On 3.8.4, `ExtractSemanticInfo` runs **before `posttyper`** and writes each unit's `.semanticdb` inside its own `runOn` — so a plugin phase anchored `runsAfter = extractSemanticDBExtractSemanticInfo`, `runsBefore = posttyper` provably sees the written file with the exact tree the extractor traversed. No phase-plan rewriting needed; the entire ResearchPlugin rationale dissolves.
- Injected symbols are built with dotty's own `SemanticSymbolBuilder`, so they are byte-identical to what dotty emits for real members (e.g. `me/jiuyang/zaozitest/BundleSpecIO#a.`) — occurrences group naturally in every SemanticDB consumer.
- Fixed while absorbing: the global cross-run registry (leaked across zinc/mill worker compiles) is gone — per-unit state only; usage symbols are synthesized from the receiver's **type**, so incremental compiles of a use-site file work without the defining file in the same run; occurrences are rewritten only on span+symbol proof (no bare-name global matching); `-semanticdb-target` honored; field detection is type-based (`BundleField[?]`, incl. `Option`-wrapped) instead of rhs-shape guessing; tests assert the real emitted protobuf (exact symbols, definition/reference spans, idempotence, no-bundle files byte-identical) instead of registry stats.
- **Interactive-pipeline safety**: `Plugins.schedule` throws (`key not found: extractSemanticDBExtractSemanticInfo`) if a `runsAfter` anchor is absent from the active pipeline — which aborts the presentation compiler's `InteractiveDriver` constructor in IDE contexts that forward `-Xplugin` (Metals, scala3-bsp-semantic-ls). The plugin therefore probes `ctx.base.phasePlan` in `initialize` and contributes **no phases** when its anchors are absent (batch extraction is the only place SemanticDB exists, so nothing is lost). A regression test boots a real `InteractiveDriver` with the plugin jar.

## Verification

Zaozi ladder (all in the dev shell): `__.compile` 1153/1153 · `__.testForked` 1174/1174 (incl. 9 plugin tests) · `__.checkFormat` 69/69.

Language-server end-to-end (scala3-bsp-semantic-ls driving the FULL workspace through headless Neovim, presentation-compiler island + index both live): definition on `io.a` → `UIntSpec.scala:23` and on `io.empty` → `stdlib/src/Queue.scala:37` (cross-file); hover answers at both accesses; **references on `UIntSpecIO#a` = 19 sites (definition + 18 dynamic accesses), on `QueueIO#empty` = 2 sites across files** — i.e. the occurrences this plugin injects flow through BSP compile → index → editor. The interactive gates run with **no editor-side plugin configuration at all**: navigation arrives purely through the build's `-Xplugin` over `buildTarget/scalacOptions`.

Closes #91 (absorbed here with credit — the detection idea and the enhancement target are #91's).
