### PR TITLE
[zaozi][circtlib] Add forceable ProbeWrite API

### DIFF
--- a/circtlib/src/dialect/firrtl/DeclarationAPI.scala
+++ b/circtlib/src/dialect/firrtl/DeclarationAPI.scala
@@ -27,6 +27,16 @@ end InstanceApi
 class Mem(val _operation: Operation)
 class Node(val _operation: Operation)
 trait NodeApi     extends HasOperation[Node]:
+  inline def op(
+    name:        String,
+    location:    Location,
+    nameKind:    FirrtlNameKind,
+    input:       Value,
+    forceable:   Boolean = false
+  )(
+    using arena: Arena,
+    context:     Context
+  ): Node
 end NodeApi
 class Object(val _operation: Operation)
 class Reg(val _operation: Operation)
@@ -37,7 +47,8 @@ trait RegApi      extends HasOperation[Reg]:
     nameKind:    FirrtlNameKind,
     tpe:         Type,
     clock:       Value,
-    clockEdge:   FirrtlEventControl
+    clockEdge:   FirrtlEventControl,
+    forceable:   Boolean = false
   )(
     using arena: Arena,
     context:     Context
@@ -95,7 +106,8 @@ trait RegResetApi extends HasOperation[RegReset]:
     resetValue:    Value,
     clockEdge:     FirrtlEventControl,
     resetType:     RegResetType,
-    resetPolarity: RegResetPolarity
+    resetPolarity: RegResetPolarity,
+    forceable:     Boolean = false
   )(
     using arena:   Arena,
     context:       Context
@@ -107,7 +119,8 @@ trait WireApi     extends HasOperation[Wire]:
     name:        String,
     location:    Location,
     nameKind:    FirrtlNameKind,
-    tpe:         Type
+    tpe:         Type,
+    forceable:   Boolean = false
   )(
     using arena: Arena,
     context:     Context

--- a/circtlib/src/dialect/firrtl/Implementation.scala
+++ b/circtlib/src/dialect/firrtl/Implementation.scala
@@ -12,6 +12,7 @@ import org.llvm.circt.scalalib.capi.dialect.firrtl.{
   given
 }
 import org.llvm.mlir.scalalib.capi.ir.{
+  AttributeApi,
   Block,
   Context,
   Location,
@@ -432,7 +433,8 @@ given NodeApi with
     name:        String,
     location:    Location,
     nameKind:    FirrtlNameKind,
-    input:       Value
+    input:       Value,
+    forceable:   Boolean
   )(
     using arena: Arena,
     context:     Context
@@ -454,10 +456,12 @@ given NodeApi with
             // namedAttributeApi.namedAttributeGet("inner_sym".identifierGet, ???),
             // ::mlir::UnitAttr
             // namedAttributeApi.namedAttributeGet("forceable".identifierGet, ???)
+          ) ++ Option.when(forceable)(
+            namedAttributeApi.namedAttributeGet("forceable".identifierGet, summon[AttributeApi].unitAttrGet)
           )
         ,
         operands = Seq(input),
-        inferredResultsTypes = Some(1)
+        inferredResultsTypes = Some(if forceable then 2 else 1)
       )
     )
   extension (ref: Node) def operation: Operation = ref._operation
@@ -470,7 +474,8 @@ given RegApi with
     nameKind:    FirrtlNameKind,
     tpe:         Type,
     clock:       Value,
-    clockEdge:   FirrtlEventControl
+    clockEdge:   FirrtlEventControl,
+    forceable:   Boolean
   )(
     using arena: Arena,
     context:     Context
@@ -496,10 +501,12 @@ given RegApi with
           // namedAttributeApi.namedAttributeGet("inner_sym".identifierGet, ???),
           // ::mlir::UnitAttr
           // namedAttributeApi.namedAttributeGet("forceable".identifierGet, ???)
+        ) ++ Option.when(forceable)(
+          namedAttributeApi.namedAttributeGet("forceable".identifierGet, summon[AttributeApi].unitAttrGet)
         )
       ,
       operands = Seq(clock),
-      resultsTypes = Some(Seq(tpe))
+      resultsTypes = Some(Seq(tpe) ++ Option.when(forceable)(tpe.getRef(true)))
     )
   )
   extension (ref: Reg) def operation: Operation = ref._operation
@@ -515,7 +522,8 @@ given RegResetApi with
     resetValue:    Value,
     clockEdge:     FirrtlEventControl,
     resetType:     RegResetType,
-    resetPolarity: RegResetPolarity
+    resetPolarity: RegResetPolarity,
+    forceable:     Boolean
   )(
     using arena:   Arena,
     context:       Context
@@ -551,10 +559,12 @@ given RegResetApi with
           // namedAttributeApi.namedAttributeGet("inner_sym".identifierGet, ???),
           // ::mlir::UnitAttr
           // namedAttributeApi.namedAttributeGet("forceable".identifierGet, ???)
+        ) ++ Option.when(forceable)(
+          namedAttributeApi.namedAttributeGet("forceable".identifierGet, summon[AttributeApi].unitAttrGet)
         )
       ,
       operands = Seq(clock, reset, resetValue),
-      resultsTypes = Some(Seq(tpe))
+      resultsTypes = Some(Seq(tpe) ++ Option.when(forceable)(tpe.getRef(true)))
     )
   )
   extension (ref: RegReset) def operation: Operation = ref._operation
@@ -564,7 +574,8 @@ given WireApi with
     name:        String,
     location:    Location,
     nameKind:    FirrtlNameKind,
-    tpe:         Type
+    tpe:         Type,
+    forceable:   Boolean
   )(
     using arena: Arena,
     context:     Context
@@ -586,9 +597,11 @@ given WireApi with
             // namedAttributeApi.namedAttributeGet("inner_sym".identifierGet, ???),
             // ::mlir::UnitAttr
             // namedAttributeApi.namedAttributeGet("forceable".identifierGet, ???)
+          ) ++ Option.when(forceable)(
+            namedAttributeApi.namedAttributeGet("forceable".identifierGet, summon[AttributeApi].unitAttrGet)
           )
         ,
-        resultsTypes = Some(Seq(tpe))
+        resultsTypes = Some(Seq(tpe) ++ Option.when(forceable)(tpe.getRef(true)))
       )
     )
   extension (ref: Wire)
@@ -723,7 +736,7 @@ given RefReleaseInitialApi with
   ): RefReleaseInitial =
     RefReleaseInitial(
       summon[OperationApi].operationCreate(
-        name = "firrtl.ref.release",
+        name = "firrtl.ref.release_initial",
         location = location,
         operands = Seq(predicate, dest)
       )

--- a/circtlib/tests/src/Smoke.scala
+++ b/circtlib/tests/src/Smoke.scala
@@ -99,6 +99,27 @@ object Smoke extends TestSuite:
               w1.operation.appendToBlock()
               summon[ConnectApi].op(w0.result, w1.result, unknownLocation).operation.appendToBlock()
 
+            test("test_ref_release_initial_uses_distinct_operation"):
+              val predicate = summon[ConstantApi].op(
+                input = BigInt(1),
+                width = 1,
+                signed = false,
+                location = unknownLocation
+              )
+              val target    = summon[WireApi].op(
+                name = "forceableTarget",
+                location = unknownLocation,
+                nameKind = FirrtlNameKind.Droppable,
+                tpe = 1.getUInt,
+                forceable = true
+              )
+              val release   = summon[RefReleaseInitialApi].op(
+                predicate.result,
+                target.operation.getResult(1),
+                unknownLocation
+              )
+              assert(release.operation.getName.str == "firrtl.ref.release_initial")
+
           test("Structure"):
             test("Instance"):
               summon[InstanceApi]

--- a/zaozi/src/Api.scala
+++ b/zaozi/src/Api.scala
@@ -38,6 +38,8 @@ trait LayerTree:
         override def parent:   Option[LayerTree] = _parent
     rebuildLayer(this, None)
 
+final class DVLayerScope private[zaozi] ()
+
 /** Serializable Layer definition. */
 case class Layer(name: String, children: Seq[Layer] = Seq.empty):
   layer =>
@@ -341,6 +343,18 @@ trait ConstructorApi:
     sourcecode.Name.Machine,
     InstanceContext
   ):   Wire[T]
+  def Wire[T <: Data & CanProbe](
+    refType:   T,
+    forceable: true
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ):   Wire[T] & ForceableReferable[T]
   def Reg[T <: Data](
     refType: T
   )(
@@ -354,6 +368,20 @@ trait ConstructorApi:
     sourcecode.Name.Machine,
     InstanceContext
   ):   Reg[T]
+  def Reg[T <: Data & CanProbe](
+    refType:   T,
+    forceable: true
+  )(
+    using ClockScope
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ):   Reg[T] & ForceableReferable[T]
   def RegInit[T <: Data](
     input: Const[T]
   )(
@@ -369,6 +397,22 @@ trait ConstructorApi:
     sourcecode.Name.Machine,
     InstanceContext
   ):   Reg[T]
+  def RegInit[T <: Data & CanProbe](
+    input:     Const[T],
+    forceable: true
+  )(
+    using ClockScope
+  )(
+    using ResetScope
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ):   Reg[T] & ForceableReferable[T]
   def Node[T <: Data](
     ref: Referable[T]
   )(
@@ -380,6 +424,18 @@ trait ConstructorApi:
     sourcecode.Name.Machine,
     InstanceContext
   ):   Node[T]
+  def Node[T <: Data & CanProbe](
+    ref:       Referable[T],
+    forceable: true
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ):   Node[T] & ForceableReferable[T]
   extension (bigInt: BigInt)
     def U(
       width: Int
@@ -577,6 +633,42 @@ trait ProbeConnect[D <: Data & CanProbe, P <: RWProbe[D] | RProbe[D], DATA <: Re
       Context,
       Block,
       LayerTree,
+      sourcecode.File,
+      sourcecode.Line
+    ): Unit
+
+trait ProbeWriteApi:
+  def ProbeWrite[T <: Data & CanProbe](
+    target: ForceableReferable[T]
+  )(
+    using Arena,
+    Context,
+    Block,
+    DVLayerScope
+  ): ProbeWrite[T]
+
+  extension [T <: Data & CanProbe](probe: ProbeWrite[T])
+    def force(
+      predicate: Referable[Bool],
+      value:     Referable[T]
+    )(
+      using ClockScope,
+      Arena,
+      Context,
+      Block,
+      DVLayerScope,
+      sourcecode.File,
+      sourcecode.Line
+    ): Unit
+
+    def release(
+      predicate: Referable[Bool]
+    )(
+      using ClockScope,
+      Arena,
+      Context,
+      Block,
+      DVLayerScope,
       sourcecode.File,
       sourcecode.Line
     ): Unit

--- a/zaozi/src/default/ConstructorApi.scala
+++ b/zaozi/src/default/ConstructorApi.scala
@@ -151,12 +151,38 @@ given ConstructorApi with
       name = valName,
       location = locate,
       nameKind = FirrtlNameKind.Interesting,
-      tpe = refType.toMlirType
+      tpe = refType.toMlirType,
+      forceable = false
     )
     wireOp.operation.appendToBlock()
     new Wire[T]:
       val _tpe:   T     = refType
       val _refer: Value = wireOp.operation.getResult(0)
+
+  def Wire[T <: Data & CanProbe](
+    refType:   T,
+    forceable: true
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Wire[T] & ForceableReferable[T] =
+    val wireOp = summon[WireApi].op(
+      name = valName,
+      location = locate,
+      nameKind = FirrtlNameKind.Interesting,
+      tpe = refType.toMlirType,
+      forceable = forceable
+    )
+    wireOp.operation.appendToBlock()
+    new Wire[T] with ForceableReferable[T]:
+      val _tpe:            T     = refType
+      val _refer:          Value = wireOp.operation.getResult(0)
+      val _forceableRefer: Value = wireOp.operation.getResult(1)
 
   def Reg[T <: Data](
     refType: T
@@ -178,12 +204,43 @@ given ConstructorApi with
       nameKind = FirrtlNameKind.Interesting,
       tpe = refType.toMlirType,
       clock = clockScope.clock.refer,
-      clockEdge = clockScope.clockEdge
+      clockEdge = clockScope.clockEdge,
+      forceable = false
     )
     regOp.operation.appendToBlock()
     new Reg[T]:
       val _tpe:   T     = refType
       val _refer: Value = regOp.operation.getResult(0)
+
+  def Reg[T <: Data & CanProbe](
+    refType:   T,
+    forceable: true
+  )(
+    using ClockScope
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Reg[T] & ForceableReferable[T] =
+    val clockScope = summon[ClockScope]
+    val regOp      = summon[RegApi].op(
+      name = valName,
+      location = locate,
+      nameKind = FirrtlNameKind.Interesting,
+      tpe = refType.toMlirType,
+      clock = clockScope.clock.refer,
+      clockEdge = clockScope.clockEdge,
+      forceable = forceable
+    )
+    regOp.operation.appendToBlock()
+    new Reg[T] with ForceableReferable[T]:
+      val _tpe:            T     = refType
+      val _refer:          Value = regOp.operation.getResult(0)
+      val _forceableRefer: Value = regOp.operation.getResult(1)
 
   def RegInit[T <: Data](
     input: Const[T]
@@ -212,12 +269,50 @@ given ConstructorApi with
       resetValue = input.refer,
       clockEdge = clockScope.clockEdge,
       resetType = resetScope.resetType,
-      resetPolarity = resetScope.resetPolarity
+      resetPolarity = resetScope.resetPolarity,
+      forceable = false
     )
     regResetOp.operation.appendToBlock()
     new Reg[T]:
       val _tpe:   T     = input._tpe
       val _refer: Value = regResetOp.operation.getResult(0)
+
+  def RegInit[T <: Data & CanProbe](
+    input:     Const[T],
+    forceable: true
+  )(
+    using ClockScope
+  )(
+    using ResetScope
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Reg[T] & ForceableReferable[T] =
+    val clockScope = summon[ClockScope]
+    val resetScope = summon[ResetScope]
+    val regResetOp = summon[RegResetApi].op(
+      name = valName,
+      location = locate,
+      nameKind = FirrtlNameKind.Interesting,
+      tpe = input._tpe.toMlirType,
+      clock = clockScope.clock.refer,
+      reset = resetScope.reset.refer,
+      resetValue = input.refer,
+      clockEdge = clockScope.clockEdge,
+      resetType = resetScope.resetType,
+      resetPolarity = resetScope.resetPolarity,
+      forceable = forceable
+    )
+    regResetOp.operation.appendToBlock()
+    new Reg[T] with ForceableReferable[T]:
+      val _tpe:            T     = input._tpe
+      val _refer:          Value = regResetOp.operation.getResult(0)
+      val _forceableRefer: Value = regResetOp.operation.getResult(1)
 
   def Node[T <: Data](
     ref: Referable[T]
@@ -234,12 +329,38 @@ given ConstructorApi with
       name = valName,
       location = locate,
       nameKind = FirrtlNameKind.Interesting,
-      input = ref.refer
+      input = ref.refer,
+      forceable = false
     )
     nodeOp.operation.appendToBlock()
     new Node[T]:
       val _tpe:   T     = ref._tpe
       val _refer: Value = nodeOp.operation.getResult(0)
+
+  def Node[T <: Data & CanProbe](
+    ref:       Referable[T],
+    forceable: true
+  )(
+    using Arena,
+    Context,
+    Block,
+    sourcecode.File,
+    sourcecode.Line,
+    sourcecode.Name.Machine,
+    InstanceContext
+  ): Node[T] & ForceableReferable[T] =
+    val nodeOp = summon[NodeApi].op(
+      name = valName,
+      location = locate,
+      nameKind = FirrtlNameKind.Interesting,
+      input = ref.refer,
+      forceable = forceable
+    )
+    nodeOp.operation.appendToBlock()
+    new Node[T] with ForceableReferable[T]:
+      val _tpe:            T     = ref._tpe
+      val _refer:          Value = nodeOp.operation.getResult(0)
+      val _forceableRefer: Value = nodeOp.operation.getResult(1)
 
   extension (bigInt: BigInt)
     def U(

--- a/zaozi/src/default/ProbeWriteApi.scala
+++ b/zaozi/src/default/ProbeWriteApi.scala
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Zaozi contributors
+package me.jiuyang.zaozi.default
+
+import me.jiuyang.zaozi.{ClockScope, DVLayerScope, LayerTree, ProbeWriteApi}
+import me.jiuyang.zaozi.reftpe.{ForceableReferable, ProbeWrite, Referable}
+import me.jiuyang.zaozi.valuetpe.{Bool, CanProbe, Data}
+
+import org.llvm.circt.scalalib.capi.dialect.firrtl.FirrtlEventControl
+import org.llvm.circt.scalalib.dialect.firrtl.operation.{RefForceApi, RefReleaseApi, given}
+import org.llvm.mlir.scalalib.capi.ir.{Block, Context, given}
+
+import java.lang.foreign.Arena
+
+export given_ProbeWriteApi.{force, release, ProbeWrite}
+
+given given_DVLayerScope(
+  using Arena,
+  Block,
+  LayerTree
+): DVLayerScope =
+  require(
+    summon[Block].getParentOperation.getName.str == "firrtl.layerblock",
+    "ProbeWrite requires a FIRRTL layer block"
+  )
+  new DVLayerScope
+
+given ProbeWriteApi with
+  def ProbeWrite[T <: Data & CanProbe](
+    target: ForceableReferable[T]
+  )(
+    using Arena,
+    Context,
+    Block,
+    DVLayerScope
+  ): ProbeWrite[T] =
+    new ProbeWrite[T]:
+      val _tpe   = target._tpe
+      val _refer = target._forceableRefer
+
+  extension [T <: Data & CanProbe](probe: ProbeWrite[T])
+    def force(
+      predicate: Referable[Bool],
+      value:     Referable[T]
+    )(
+      using ClockScope,
+      Arena,
+      Context,
+      Block,
+      DVLayerScope,
+      sourcecode.File,
+      sourcecode.Line
+    ): Unit =
+      require(
+        summon[ClockScope].clockEdge == FirrtlEventControl.AtPosEdge,
+        "clocked ProbeWrite supports posedge clocks only"
+      )
+      val op = summon[RefForceApi].op(
+        summon[ClockScope].clock.refer,
+        predicate.refer,
+        probe._refer,
+        value.refer,
+        locate
+      )
+      op.operation.appendToBlock()
+
+    def release(
+      predicate: Referable[Bool]
+    )(
+      using ClockScope,
+      Arena,
+      Context,
+      Block,
+      DVLayerScope,
+      sourcecode.File,
+      sourcecode.Line
+    ): Unit =
+      require(
+        summon[ClockScope].clockEdge == FirrtlEventControl.AtPosEdge,
+        "clocked ProbeWrite supports posedge clocks only"
+      )
+      val op = summon[RefReleaseApi].op(
+        summon[ClockScope].clock.refer,
+        predicate.refer,
+        probe._refer,
+        locate
+      )
+      op.operation.appendToBlock()

--- a/zaozi/src/reftpe/ProbeWrite.scala
+++ b/zaozi/src/reftpe/ProbeWrite.scala
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Zaozi contributors
+package me.jiuyang.zaozi.reftpe
+
+import me.jiuyang.zaozi.valuetpe.{CanProbe, Data}
+import org.llvm.mlir.scalalib.capi.ir.Value
+
+trait ForceableReferable[T <: Data & CanProbe] extends Referable[T]:
+  private[zaozi] val _forceableRefer: Value
+
+/** A write-capable reference to a forceable declaration. */
+abstract class ProbeWrite[T <: Data & CanProbe]:
+  private[zaozi] val _tpe:   T
+  private[zaozi] val _refer: Value

--- a/zaozi/tests/src/ProbeWriteSpec.scala
+++ b/zaozi/tests/src/ProbeWriteSpec.scala
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 Zaozi contributors
+package me.jiuyang.zaozitest
+
+import me.jiuyang.testlib.{HasFirrtlTest, HasVerilogTest}
+import me.jiuyang.zaozi.*
+import me.jiuyang.zaozi.default.{*, given}
+import me.jiuyang.zaozi.reftpe.Interface
+import me.jiuyang.zaozi.valuetpe.*
+import utest.*
+
+case class ProbeWriteSpecParameter() extends Parameter
+given upickle.default.ReadWriter[ProbeWriteSpecParameter] = upickle.default.macroRW
+
+class ProbeWriteSpecLayers(parameter: ProbeWriteSpecParameter) extends LayerInterface(parameter):
+  def layers = Seq(Layer("DV"))
+
+class ProbeWriteSpecIO(parameter: ProbeWriteSpecParameter) extends HWBundle(parameter):
+  val clock:          BundleField[Clock] = Flipped(Clock())
+  val reset:          BundleField[Reset] = Flipped(Reset())
+  val force_enable:   BundleField[Bool]  = Flipped(Bool())
+  val release_enable: BundleField[Bool]  = Flipped(Bool())
+  val force_value:    BundleField[UInt]  = Flipped(UInt(3))
+  val state:          BundleField[UInt]  = Aligned(UInt(3))
+
+class ProbeWriteSpecProbe(parameter: ProbeWriteSpecParameter)
+    extends DVBundle[ProbeWriteSpecParameter, ProbeWriteSpecLayers](parameter)
+
+object ProbeWriteSpec extends TestSuite:
+  @generator
+  object ForceableRegister
+      extends Generator[
+        ProbeWriteSpecParameter,
+        ProbeWriteSpecLayers,
+        ProbeWriteSpecIO,
+        ProbeWriteSpecProbe
+      ]
+      with HasFirrtlTest
+      with HasVerilogTest:
+    def architecture(parameter: ProbeWriteSpecParameter) =
+      val io           = summon[Interface[ProbeWriteSpecIO]]
+      given ClockScope = ClockScope.posedge(io.clock)
+      given ResetScope = ResetScope.asyncActiveHigh(io.reset)
+
+      val state = RegInit(0.U(3), forceable = true)
+      state    := (state + 1.U).asBits.tail(3).asUInt
+      io.state := state
+
+      layer("DV"):
+        val writeProbe = ProbeWrite(state)
+        writeProbe.force(io.force_enable, io.force_value)
+        writeProbe.release(io.release_enable)
+
+  @generator
+  object AllForceableDeclarations
+      extends Generator[
+        ProbeWriteSpecParameter,
+        ProbeWriteSpecLayers,
+        ProbeWriteSpecIO,
+        ProbeWriteSpecProbe
+      ]
+      with HasFirrtlTest
+      with HasVerilogTest:
+    def architecture(parameter: ProbeWriteSpecParameter) =
+      val io           = summon[Interface[ProbeWriteSpecIO]]
+      given ClockScope = ClockScope.posedge(io.clock)
+      given ResetScope = ResetScope.asyncActiveHigh(io.reset)
+
+      val forceableWire     = Wire(UInt(3), forceable = true)
+      val forceableReg      = Reg(UInt(3), forceable = true)
+      val forceableRegReset = RegInit(0.U(3), forceable = true)
+      val forceableNode     = Node(forceableRegReset, forceable = true)
+      forceableWire     := io.force_value
+      forceableReg      := forceableWire
+      forceableRegReset := forceableReg
+      io.state          := forceableNode
+
+      layer("DV"):
+        ProbeWrite(forceableWire).force(io.force_enable, io.force_value)
+        ProbeWrite(forceableReg).force(io.force_enable, io.force_value)
+        ProbeWrite(forceableRegReset).release(io.release_enable)
+        ProbeWrite(forceableNode).release(io.release_enable)
+
+  @generator
+  object NegedgeForceableRegister
+      extends Generator[
+        ProbeWriteSpecParameter,
+        ProbeWriteSpecLayers,
+        ProbeWriteSpecIO,
+        ProbeWriteSpecProbe
+      ]
+      with HasFirrtlTest:
+    def architecture(parameter: ProbeWriteSpecParameter) =
+      val io           = summon[Interface[ProbeWriteSpecIO]]
+      given ClockScope = ClockScope.negedge(io.clock)
+      given ResetScope = ResetScope.asyncActiveHigh(io.reset)
+
+      val state = RegInit(0.U(3), forceable = true)
+      state    := io.force_value
+      io.state := state
+
+      layer("DV"):
+        ProbeWrite(state).force(io.force_enable, io.force_value)
+
+  val tests = Tests:
+    test("test_forceable_regreset_emits_clocked_probewrite_operations"):
+      ForceableRegister.firrtlTest(ProbeWriteSpecParameter())(
+        "forceable",
+        "force(",
+        "release("
+      )
+
+    test("test_forceable_regreset_lowers_to_dv_bind_force_and_release"):
+      ForceableRegister.verilogTest(ProbeWriteSpecParameter())(
+        "module ForceableRegister_DV",
+        "always @(posedge ForceableRegister.clock)",
+        "force ForceableRegister.state",
+        "release ForceableRegister.state",
+        "bind ForceableRegister ForceableRegister_DV"
+      )
+
+    test("test_forceable_wire_reg_regreset_node_emit_rwprobe_results"):
+      AllForceableDeclarations.firrtlTest(ProbeWriteSpecParameter()): output =>
+        output.linesIterator.count(_.contains(" forceable :")) == 4 &&
+          output.contains("force(") &&
+          output.contains("release(")
+
+    test("test_forceable_wire_reg_regreset_node_lower_through_dv_bind"):
+      AllForceableDeclarations.verilogTest(ProbeWriteSpecParameter())(
+        "module AllForceableDeclarations_DV",
+        "bind AllForceableDeclarations AllForceableDeclarations_DV"
+      )
+
+    test("test_clocked_probewrite_rejects_negedge_scope"):
+      val error = intercept[IllegalArgumentException]:
+        NegedgeForceableRegister.firrtlString(ProbeWriteSpecParameter())
+      assert(error.getMessage.contains("posedge clocks only"))


### PR DESCRIPTION
## Summary

- Add low-level and typed `forceable = true` declaration APIs.
- Return a typed `ForceableReferable` carrying the declaration RWProbe.
- Add clocked `ProbeWrite.force` and `ProbeWrite.release` for DV layers.
- Reject use outside a DV layer and reject non-positive-edge clock scopes.
- Correct `releaseInitial` to emit `firrtl.ref.release_initial`.
- Add named API and lowering regressions for every supported declaration kind.

## Safety constraints

The typed forceable overloads require `CanProbe`, limiting the API to supported ground data types. Probe writes require a `DVLayerScope` derived from a `firrtl.layerblock`, so production RTL cannot obtain the capability accidentally.

## Dependency

Depends on xinpian-tech/circt#13 for forceable register and colored-reference loop analysis.

## Validation

`circtlib.tests.compile` completed successfully. Full Zaozi test compilation, `checkFormat`, and the shared CIRCT/Zaozi integration build remain to be completed on this draft.