### PR TITLE
[lsp] rename scala3-bsp-semantic-ls to zaozi-lsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .jvm-opts
 .mill-jvm-opts
 .metals/
-.scala3-bsp-semantic-ls/
+.zaozi-lsp/
 .zed/
 .vscode/
 .envrc

--- a/build.mill
+++ b/build.mill
@@ -38,7 +38,7 @@ trait ZaoziScalaModule extends ScalaModule {
       "-java-output-version",
       "25",
       // Emit SemanticDB so the project can be indexed by SemanticDB-based
-      // tooling (Metals, scalafix, scala3-bsp-semantic-ls). Built into the
+      // tooling (Metals, scalafix, zaozi-lsp). Built into the
       // Scala 3 compiler; -sourceroot keeps emitted URIs workspace-relative.
       "-Xsemanticdb",
       "-sourceroot",

--- a/doc/development.md
+++ b/doc/development.md
@@ -33,7 +33,7 @@ after you installed the dependencies and set the env. You can use
 
 ### Zed
 
-Install the `scala3-bsp-semantic-ls` Zed adapter through the Nix-managed Zed
+Install the `zaozi-lsp` Zed adapter through the Nix-managed Zed
 configuration, then launch Zed from the project development environment:
 
 ```shell
@@ -44,7 +44,7 @@ Depending on the Zed installation, the command may be named `zed` instead of
 `zeditor`. Trust the worktree when Zed prompts for it so project settings and
 language servers are enabled. On Linux, the development shell hook generates
 the project-level `.zed/settings.json`, selecting the
-`scala3-bsp-semantic-ls` adapter and its exact Nix store binary path. Zed does
+`zaozi-lsp` adapter and its exact Nix store binary path. Zed does
 not discover or download the server. The existing development-shell hook also
 generates `.bsp/mill-bsp.json`; the shared Mill module enables the SemanticDB
 options required by the server.

--- a/flake.lock
+++ b/flake.lock
@@ -76,7 +76,7 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
-          "scala3-bsp-semantic-ls",
+          "zaozi-lsp",
           "mill-ivy-fetcher",
           "nixpkgs"
         ]
@@ -257,29 +257,7 @@
         "flake-utils": "flake-utils",
         "mvn-trace-forge": "mvn-trace-forge",
         "nixpkgs": "nixpkgs_3",
-        "scala3-bsp-semantic-ls": "scala3-bsp-semantic-ls"
-      }
-    },
-    "scala3-bsp-semantic-ls": {
-      "inputs": {
-        "crane": "crane",
-        "flake-utils": "flake-utils_2",
-        "mill-ivy-fetcher": "mill-ivy-fetcher",
-        "nixpkgs": "nixpkgs_5",
-        "zaozi": "zaozi"
-      },
-      "locked": {
-        "lastModified": 1784826247,
-        "narHash": "sha256-KUmeMwE5NUxu5kVswrwhPIiRB4FWEZAusadd4GvtWoI=",
-        "owner": "xinpian-tech",
-        "repo": "scala3-bsp-semantic-ls",
-        "rev": "b0af17cbfdbc22f247e6c4dc6e31ed4b041beafe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "xinpian-tech",
-        "repo": "scala3-bsp-semantic-ls",
-        "type": "github"
+        "zaozi-lsp": "zaozi-lsp"
       }
     },
     "slang-src": {
@@ -353,7 +331,7 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
-          "scala3-bsp-semantic-ls",
+          "zaozi-lsp",
           "mill-ivy-fetcher",
           "nixpkgs"
         ]
@@ -385,6 +363,28 @@
       "original": {
         "owner": "xinpian-tech",
         "repo": "zaozi",
+        "type": "github"
+      }
+    },
+    "zaozi-lsp": {
+      "inputs": {
+        "crane": "crane",
+        "flake-utils": "flake-utils_2",
+        "mill-ivy-fetcher": "mill-ivy-fetcher",
+        "nixpkgs": "nixpkgs_5",
+        "zaozi": "zaozi"
+      },
+      "locked": {
+        "lastModified": 1786273561,
+        "narHash": "sha256-mKMAIeyF1Rg2X4AbhqAspvz5VLJCrysDCZJ2PDnDyQA=",
+        "owner": "xinpian-tech",
+        "repo": "zaozi-lsp",
+        "rev": "caba368ee9d7abd2c63118943bd62b71f1ed3f0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "xinpian-tech",
+        "repo": "zaozi-lsp",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     circt-nix.url = "github:xinpian-tech/circt-nix/xinpian-main";
     flake-utils.url = "github:numtide/flake-utils";
     mvn-trace-forge.url = "github:Avimitin/mvn-trace-forge";
-    scala3-bsp-semantic-ls.url = "github:xinpian-tech/scala3-bsp-semantic-ls";
+    zaozi-lsp.url = "github:xinpian-tech/zaozi-lsp";
   };
 
   outputs =
@@ -17,7 +17,7 @@
     , flake-utils
     , mvn-trace-forge
     , circt-nix
-    , scala3-bsp-semantic-ls
+    , zaozi-lsp
     , ...
     }:
     let
@@ -41,18 +41,18 @@
           ];
           inherit system;
         };
-        scala3BspSemanticLs = scala3-bsp-semantic-ls.packages.${system}.default;
+        zaoziLsp = zaozi-lsp.packages.${system}.default;
         zedSettings = pkgs.writeText "zaozi-zed-settings.json" ''
           {
             "languages": {
               "Scala": {
-                "language_servers": ["scala3-bsp-semantic-ls"]
+                "language_servers": ["zaozi-lsp"]
               }
             },
             "lsp": {
-              "scala3-bsp-semantic-ls": {
+              "zaozi-lsp": {
                 "binary": {
-                  "path": "${scala3BspSemanticLs}/bin/scala3-bsp-semantic-ls",
+                  "path": "${zaoziLsp}/bin/zaozi-lsp",
                   "arguments": []
                 }
               }
@@ -72,7 +72,7 @@
         devShells.default = pkgs.mkShell {
           inputsFrom = [ pkgs.zaozi.zaozi-assembly ];
           nativeBuildInputs = with pkgs; [ mtf nixd jdk25 ] ++ lib.optionals stdenv.isLinux [
-            scala3BspSemanticLs
+            zaoziLsp
           ];
           env = with pkgs; {
             CIRCT_INSTALL_PATH = circt-install;

--- a/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
+++ b/zaozi-compiler-plugin/src/me/jiuyang/zaozi/plugin/ZaoziSemanticDBPlugin.scala
@@ -28,7 +28,7 @@ import java.nio.file.{Files, Path, Paths}
   * `io.selectDynamic("field")`, a transparent inline macro that expands to `subRef`/`subRefOption` calls, where `io` is
   * a `Referable[T]` or an `Interface[T]`. Vanilla SemanticDB therefore records an occurrence of
   * `Referable#selectDynamic().` (or `Interface#selectDynamic().`) at the `field` position instead of the bundle field
-  * itself, so SemanticDB-first tooling (scala3-bsp-semantic-ls, Metals, scalafix) cannot resolve go-to-definition or
+  * itself, so SemanticDB-first tooling (zaozi-lsp, Metals, scalafix) cannot resolve go-to-definition or
   * find-references for bundle fields.
   *
   * This [[StandardPlugin]] hosts the two pipeline-dispatched zaozi tooling phases (see [[initialize]] for the dispatch
@@ -63,7 +63,7 @@ class ZaoziSemanticDBPlugin extends StandardPlugin:
     *
     * The plugin jar travels on the modules' scalacOptions, so any dotty pipeline that honors `-Xplugin` loads this
     * plugin: the batch compiler (zinc/mill), the interactive presentation compiler (`InteractiveDriver` — Metals and
-    * the scala3-bsp-semantic-ls PC islands; its pipeline is only parser/typer/SetRootTree/cookComments), scaladoc's
+    * the zaozi-lsp PC islands; its pipeline is only parser/typer/SetRootTree/cookComments), scaladoc's
     * tasty inspector (ReadTasty/TastyInspectorPhase), and the REPL (full batch pipeline). Contributing a phase whose
     * `runsAfter`/`runsBefore` anchors are absent from the active plan makes `Plugins.schedule` throw
     * `NoSuchElementException: key not found: <anchor>` while propagating ordering constraints — which aborts


### PR DESCRIPTION
zaozi-lsp is renamed in https://github.com/xinpian-tech/zaozi-lsp instead of https://github.com/xinpian-tech/scala3-bsp-semantic-ls

zaozi-lsp-zed is renamed in https://github.com/xinpian-tech/zaozi-lsp-zed instead of https://github.com/xinpian-tech/scala3-bsp-semantic-ls-zed

To update the new lsp:

In remote usage, run this in local:
```
nix run github:xinpian-tech/zaozi-lsp-zed#install
```

connect to the remote and the new wasm will be upload to the remote.

then run `nix develop .` to update the `.zed/settings.json`(if you use direnv, this maybe auto update)

then <C-S-P> run the `restart language server` in Zed cmd.
